### PR TITLE
Multiple surveys support for translations download

### DIFF
--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -41,12 +41,6 @@ export class TranslationsCommand implements ICommand {
         const surveyUuids = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
         const surveyNames = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
 
-        if (!surveyUuids && !surveyNames) {
-          throw new ValidationError(
-            `Either ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} or ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} must be provided`
-          );
-        }
-
         // Collect all surveys to process — fetch UUIDs and names in parallel
         const [surveyUuidResults, surveyNameResults] = await Promise.all([
           surveyUuids && surveyUuids.length > 0

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -38,41 +38,50 @@ export class TranslationsCommand implements ICommand {
 
     switch (subcommand) {
       case SUB_COMMANDS.TRANSLATIONS.DOWNLOAD: {
-        const surveyUuid = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
-        const surveyName = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
+        const surveyUuids = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
+        const surveyNames = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
 
-        if (!surveyUuid && !surveyName) {
+        if (!surveyUuids && !surveyNames) {
           throw new ValidationError(
             `Either ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} or ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} must be provided`
           );
         }
 
-        let survey: SurveyItem;
-        if (surveyUuid) {
-          survey = await surveyService.getSurveyByUuid(surveyUuid);
-        } else {
-          const surveys = await surveyService.getSurveyByName(surveyName!);
-          if (surveys.length > 1) {
-            ui.displaySurveys(surveys, getAdminSurveyEditorUrlById);
-            throw new ValidationError(
-              `More than one survey program found with name: "${surveyName}", please specify a more unique name or use ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)}`
-            );
+        // Collect all surveys to process
+        const surveyItemList: SurveyItem[] = [];
+
+        // Process survey UUIDs
+        if (surveyUuids && surveyUuids.length > 0) {
+          for (const uuid of surveyUuids) {
+            const survey = await surveyService.getSurveyByUuid(uuid as string);
+            if (!survey) {
+              throw new ValidationError(`Survey not found for UUID: "${uuid}"`);
+            }
+            surveyItemList.push(survey);
           }
-          survey = surveys[0];
         }
 
-        if (!survey) {
-          if (surveyName) {
-            throw new ValidationError(`Survey not found for name: "${surveyName}"`);
-          } else {
-            throw new ValidationError(`Survey not found for UUID: "${surveyUuid}"`);
+        // Process survey names
+        if (surveyNames && surveyNames.length > 0) {
+          for (const surveyName of surveyNames) {
+            const surveys = await surveyService.getSurveyByName(surveyName as string);
+            if (surveys.length > 1) {
+              ui.displaySurveys(surveys, getAdminSurveyEditorUrlById);
+              throw new ValidationError(
+                `More than one survey program found with name: "${surveyName}", please specify a more unique name or use ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)}`
+              );
+            }
+            if (surveys.length === 0) {
+              throw new ValidationError(`Survey not found for name: "${surveyName}"`);
+            }
+            surveyItemList.push(surveys[0]);
           }
         }
 
         log.info(`${EMOJIS.DOWNLOAD}  Starting translation download...`);
         ui.formatters.progress.startSpinner('Downloading translations file...');
         const downloadOptions: DownloadTranslationsOptions = {
-          survey: survey,
+          surveys: surveyItemList,
           // Override priority: CLI options (only when provided) > Profile config > Defaults
           languages:
             options[CLI_OPTIONS.TRANSLATIONS.LANGUAGES] ??

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -73,7 +73,7 @@ export class TranslationsCommand implements ICommand {
             );
           }
           if (surveys.length === 0) {
-            throw new ValidationError(`No survey found with name: "${surveyName}"`);
+            throw new ValidationError(`No survey program found with name: "${surveyName}"`);
           }
           surveyItemList.push(surveys[0]);
         }

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -59,11 +59,8 @@ export class TranslationsCommand implements ICommand {
 
         const surveyItemList: SurveyItem[] = [];
 
-        for (let i = 0; i < surveyUuidResults.length; i++) {
-          if (!surveyUuidResults[i]) {
-            throw new ValidationError(`Survey not found for UUID: "${surveyUuids![i]}"`);
-          }
-          surveyItemList.push(surveyUuidResults[i]!);
+        for (const survey of surveyUuidResults) {
+          surveyItemList.push(survey);
         }
 
         for (let i = 0; i < surveyNameResults.length; i++) {
@@ -76,7 +73,7 @@ export class TranslationsCommand implements ICommand {
             );
           }
           if (surveys.length === 0) {
-            throw new ValidationError(`Survey not found for name: "${surveyName}"`);
+            throw new ValidationError(`No survey found with name: "${surveyName}"`);
           }
           surveyItemList.push(surveys[0]);
         }

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -78,10 +78,13 @@ export class TranslationsCommand implements ICommand {
           surveyItemList.push(surveys[0]);
         }
 
+        // Deduplicate by survey id (same survey may be provided via UUID and name, or UUID listed twice)
+        const uniqueSurveyItemList = [...new Map(surveyItemList.map(s => [s.id, s])).values()];
+
         log.info(`${EMOJIS.DOWNLOAD}  Starting translation download...`);
         ui.formatters.progress.startSpinner('Downloading translations file...');
         const downloadOptions: DownloadTranslationsOptions = {
-          surveys: surveyItemList,
+          surveys: uniqueSurveyItemList,
           // Override priority: CLI options (only when provided) > Profile config > Defaults
           languages:
             options[CLI_OPTIONS.TRANSLATIONS.LANGUAGES] ??

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -48,10 +48,14 @@ export class TranslationsCommand implements ICommand {
         // Collect all surveys to process — fetch UUIDs and names in parallel
         const [surveyUuidResults, surveyNameResults] = await Promise.all([
           uniqueSurveyUuids.length > 0
-            ? Promise.all(uniqueSurveyUuids.map(uuid => surveyService.getSurveyByUuid(uuid as string)))
+            ? Promise.all(
+                uniqueSurveyUuids.map(uuid => surveyService.getSurveyByUuid(uuid as string))
+              )
             : Promise.resolve([]),
           uniqueSurveyNames.length > 0
-            ? Promise.all(uniqueSurveyNames.map(name => surveyService.getSurveyByName(name as string)))
+            ? Promise.all(
+                uniqueSurveyNames.map(name => surveyService.getSurveyByName(name as string))
+              )
             : Promise.resolve([]),
         ]);
 

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -47,35 +47,38 @@ export class TranslationsCommand implements ICommand {
           );
         }
 
-        // Collect all surveys to process
+        // Collect all surveys to process — fetch UUIDs and names in parallel
+        const [surveyUuidResults, surveyNameResults] = await Promise.all([
+          surveyUuids && surveyUuids.length > 0
+            ? Promise.all(surveyUuids.map(uuid => surveyService.getSurveyByUuid(uuid as string)))
+            : Promise.resolve([]),
+          surveyNames && surveyNames.length > 0
+            ? Promise.all(surveyNames.map(name => surveyService.getSurveyByName(name as string)))
+            : Promise.resolve([]),
+        ]);
+
         const surveyItemList: SurveyItem[] = [];
 
-        // Process survey UUIDs
-        if (surveyUuids && surveyUuids.length > 0) {
-          for (const uuid of surveyUuids) {
-            const survey = await surveyService.getSurveyByUuid(uuid as string);
-            if (!survey) {
-              throw new ValidationError(`Survey not found for UUID: "${uuid}"`);
-            }
-            surveyItemList.push(survey);
+        for (let i = 0; i < surveyUuidResults.length; i++) {
+          if (!surveyUuidResults[i]) {
+            throw new ValidationError(`Survey not found for UUID: "${surveyUuids![i]}"`);
           }
+          surveyItemList.push(surveyUuidResults[i]!);
         }
 
-        // Process survey names
-        if (surveyNames && surveyNames.length > 0) {
-          for (const surveyName of surveyNames) {
-            const surveys = await surveyService.getSurveyByName(surveyName as string);
-            if (surveys.length > 1) {
-              ui.displaySurveys(surveys, getAdminSurveyEditorUrlById);
-              throw new ValidationError(
-                `More than one survey program found with name: "${surveyName}", please specify a more unique name or use ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)}`
-              );
-            }
-            if (surveys.length === 0) {
-              throw new ValidationError(`Survey not found for name: "${surveyName}"`);
-            }
-            surveyItemList.push(surveys[0]);
+        for (let i = 0; i < surveyNameResults.length; i++) {
+          const surveys = surveyNameResults[i];
+          const surveyName = surveyNames![i];
+          if (surveys.length > 1) {
+            ui.displaySurveys(surveys, getAdminSurveyEditorUrlById);
+            throw new ValidationError(
+              `More than one survey program found with name: "${surveyName}", please specify a more unique name or use ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)}`
+            );
           }
+          if (surveys.length === 0) {
+            throw new ValidationError(`Survey not found for name: "${surveyName}"`);
+          }
+          surveyItemList.push(surveys[0]);
         }
 
         log.info(`${EMOJIS.DOWNLOAD}  Starting translation download...`);

--- a/src/commands/translations.ts
+++ b/src/commands/translations.ts
@@ -41,13 +41,17 @@ export class TranslationsCommand implements ICommand {
         const surveyUuids = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
         const surveyNames = options[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
 
+        // Deduplicate inputs so identical UUIDs/names don't trigger redundant API calls
+        const uniqueSurveyUuids = surveyUuids ? [...new Set(surveyUuids)] : [];
+        const uniqueSurveyNames = surveyNames ? [...new Set(surveyNames)] : [];
+
         // Collect all surveys to process — fetch UUIDs and names in parallel
         const [surveyUuidResults, surveyNameResults] = await Promise.all([
-          surveyUuids && surveyUuids.length > 0
-            ? Promise.all(surveyUuids.map(uuid => surveyService.getSurveyByUuid(uuid as string)))
+          uniqueSurveyUuids.length > 0
+            ? Promise.all(uniqueSurveyUuids.map(uuid => surveyService.getSurveyByUuid(uuid as string)))
             : Promise.resolve([]),
-          surveyNames && surveyNames.length > 0
-            ? Promise.all(surveyNames.map(name => surveyService.getSurveyByName(name as string)))
+          uniqueSurveyNames.length > 0
+            ? Promise.all(uniqueSurveyNames.map(name => surveyService.getSurveyByName(name as string)))
             : Promise.resolve([]),
         ]);
 
@@ -59,16 +63,14 @@ export class TranslationsCommand implements ICommand {
 
         for (let i = 0; i < surveyNameResults.length; i++) {
           const surveys = surveyNameResults[i];
-          const surveyName = surveyNames![i];
+          const surveyName = uniqueSurveyNames[i];
           if (surveys.length > 1) {
             ui.displaySurveys(surveys, getAdminSurveyEditorUrlById);
             throw new ValidationError(
               `More than one survey program found with name: "${surveyName}", please specify a more unique name or use ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)}`
             );
           }
-          if (surveys.length === 0) {
-            throw new ValidationError(`No survey program found with name: "${surveyName}"`);
-          }
+
           surveyItemList.push(surveys[0]);
         }
 

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -41,8 +41,8 @@ export interface CliArgs {
   uuid?: string;
 
   // Translations command
-  'survey-uuid'?: string;
-  'survey-name'?: string;
+  'survey-uuid'?: string[];
+  'survey-name'?: string[];
   'save-debug-files'?: boolean;
   file?: string;
   'pretend-upload'?: boolean;

--- a/src/core/adapters/fs/paths.ts
+++ b/src/core/adapters/fs/paths.ts
@@ -79,6 +79,13 @@ export class PathUtils {
   }
 
   /**
+   * Get the base filename from a path (cross-platform)
+   */
+  static basename(filePath: string): string {
+    return path.basename(filePath);
+  }
+
+  /**
    * Join path segments safely
    */
   static join(...segments: string[]): string {

--- a/src/core/adapters/http/interceptors.ts
+++ b/src/core/adapters/http/interceptors.ts
@@ -86,7 +86,6 @@ export class RequestInterceptor {
       log.info(`${EMOJIS.SUCCESS} Authentication successful`);
       return access_token;
     } catch (error) {
-      console.log(error);
       const message = error instanceof Error ? error.message : 'Unknown';
       log.error(
         `${EMOJIS.ERROR} Authentication failed`,

--- a/src/core/adapters/http/interceptors.ts
+++ b/src/core/adapters/http/interceptors.ts
@@ -41,7 +41,7 @@ export class RequestInterceptor {
   /**
    * Get valid token, refresh if needed
    */
-  private static async getValidToken(baseURL: string, profile: Profile): Promise<string | null> {
+  private static async getValidToken(baseURL: string, profile: Profile): Promise<string> {
     const tokenData = tokenStore.get(baseURL);
 
     // Check if current token is still valid
@@ -56,7 +56,7 @@ export class RequestInterceptor {
   /**
    * Fetch new OAuth2 token
    */
-  private static async fetchNewToken(baseURL: string, profile: Profile): Promise<string | null> {
+  private static async fetchNewToken(baseURL: string, profile: Profile): Promise<string> {
     try {
       log.info(`${EMOJIS.LOADING} Authenticating...`);
 
@@ -86,11 +86,13 @@ export class RequestInterceptor {
       log.info(`${EMOJIS.SUCCESS} Authentication successful`);
       return access_token;
     } catch (error) {
+      console.log(error);
+      const message = error instanceof Error ? error.message : 'Unknown';
       log.error(
         `${EMOJIS.ERROR} Authentication failed`,
-        error instanceof Error ? error.message : 'Unknown'
+        message
       );
-      return null;
+      throw new Error(`Authentication failed: ${message}`);
     }
   }
 

--- a/src/core/adapters/http/interceptors.ts
+++ b/src/core/adapters/http/interceptors.ts
@@ -8,6 +8,7 @@ import axios, {
 import { log } from '../../../utils';
 import { EMOJIS } from '../../config/constants';
 import { Profile } from '../../config/types';
+import { AuthenticationError } from '../../../utils/errors';
 
 // Profile management for authentication
 const profileStore: Map<string, Profile> = new Map();
@@ -91,7 +92,7 @@ export class RequestInterceptor {
         `${EMOJIS.ERROR} Authentication failed`,
         message
       );
-      throw new Error(`Authentication failed: ${message}`);
+      throw new AuthenticationError(`Authentication failed: ${message}`);
     }
   }
 

--- a/src/core/adapters/http/interceptors.ts
+++ b/src/core/adapters/http/interceptors.ts
@@ -6,9 +6,9 @@ import axios, {
 } from 'axios';
 
 import { log } from '../../../utils';
+import { AuthenticationError } from '../../../utils/errors';
 import { EMOJIS } from '../../config/constants';
 import { Profile } from '../../config/types';
-import { AuthenticationError } from '../../../utils/errors';
 
 // Profile management for authentication
 const profileStore: Map<string, Profile> = new Map();
@@ -88,10 +88,7 @@ export class RequestInterceptor {
       return access_token;
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unknown';
-      log.error(
-        `${EMOJIS.ERROR} Authentication failed`,
-        message
-      );
+      log.error(`${EMOJIS.ERROR} Authentication failed`, message);
       throw new AuthenticationError(`Authentication failed: ${message}`);
     }
   }

--- a/src/core/services/surveys/index.ts
+++ b/src/core/services/surveys/index.ts
@@ -1,2 +1,2 @@
 export { SurveysService } from './surveys-service';
-export type { SurveyListResponse, SurveyItem, WhereUsedInfo, WhereUsedMap } from './types';
+export type { SurveyListResponse, SurveyItem, WhereUsedInfo } from './types';

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -9,7 +9,6 @@ import {
   SurveyFlatViewResponse,
   SurveyItem,
   SurveyListResponse,
-  WhereUsedMap,
   WhereUsedInfo,
   SurveyModelItem,
   QuestionField,
@@ -124,8 +123,8 @@ export class SurveysService extends BaseService {
     return response;
   }
 
-  buildWhereUsedMap(surveyFlatViewResponse: SurveyFlatViewResponse): WhereUsedMap {
-    const cache = new Map<string, WhereUsedInfo>();
+  buildWhereUsedMap(surveyName: string, surveyFlatViewResponse: SurveyFlatViewResponse): Map<string, WhereUsedInfo> {
+    const whereUsedMap = new Map<string, WhereUsedInfo>();
 
     // Create lookup maps for better performance
     const surveyModelMap = new Map<string, SurveyModelItem>();
@@ -173,7 +172,7 @@ export class SurveysService extends BaseService {
       const containerPath = buildContainerPath(surveyModelElement.container?.id);
 
       return {
-        location: `${containerPath} > Question ${String(questionNumber).padStart(2, '0')}`,
+        location: `${surveyName} > ${containerPath} > Question ${String(questionNumber).padStart(2, '0')}`,
         type: 'question',
       };
     };
@@ -224,7 +223,7 @@ export class SurveysService extends BaseService {
       const containerPath = buildContainerPath(surveyModelElement.container?.id);
 
       return {
-        location: `${containerPath} > Question ${String(questionNumber).padStart(2, '0')} > Answer ${String(answerNumber).padStart(2, '0')}`,
+        location: `${surveyName} > ${containerPath} > Question ${String(questionNumber).padStart(2, '0')} > Answer ${String(answerNumber).padStart(2, '0')}`,
         type: 'alternative',
       };
     };
@@ -256,7 +255,7 @@ export class SurveysService extends BaseService {
       const containerPath = buildContainerPath(foundElement.container?.id);
 
       return {
-        location: `${containerPath} > ${elementType} ${String(elementNumber).padStart(2, '0')}`,
+        location: `${surveyName} > ${containerPath} > ${elementType} ${String(elementNumber).padStart(2, '0')}`,
         type: foundElement.type,
       };
     };
@@ -359,17 +358,36 @@ export class SurveysService extends BaseService {
       }
     };
 
-    // Build the map by processing all possible translation keys
-    // We'll populate this on-demand when keys are requested
-    return {
-      get: (key: string): WhereUsedInfo => {
-        if (!cache.has(key)) {
-          cache.set(key, resolve(key));
-        }
-        return cache.get(key) ?? { location: 'Unknown Location', type: 'unknown' };
-      },
-      has: (key: string): boolean => cache.has(key),
-      forEach: (fn: (value: WhereUsedInfo, key: string) => void): void => cache.forEach(fn),
-    };
+    // Pre-build the map by processing all possible translation keys upfront
+    // Collect all keys from question fields
+    surveyFlatViewResponse.question_fields.forEach(qf => {
+      if (qf.translation_key && !whereUsedMap.has(qf.translation_key)) {
+        whereUsedMap.set(qf.translation_key, resolve(qf.translation_key));
+      }
+    });
+
+    // Collect keys from alternative sets
+    surveyFlatViewResponse.alternative_sets.forEach(altSet => {
+      if (altSet.alternatives) {
+        altSet.alternatives.forEach(alt => {
+          if (alt.translation_key && !whereUsedMap.has(alt.translation_key)) {
+            whereUsedMap.set(alt.translation_key, resolve(alt.translation_key));
+          }
+        });
+      }
+    });
+
+    // Collect keys from survey model translation keys
+    surveyFlatViewResponse.survey_model.forEach(sm => {
+      if (sm.translation_keys) {
+        sm.translation_keys.forEach(tk => {
+          if (tk['translation-key'] && !whereUsedMap.has(tk['translation-key'])) {
+            whereUsedMap.set(tk['translation-key'], resolve(tk['translation-key']));
+          }
+        });
+      }
+    });
+
+    return whereUsedMap;
   }
 }

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -1,4 +1,7 @@
+import axios from 'axios';
+
 import { log } from '../../../utils';
+import { ValidationError } from '../../../utils/errors';
 import { HttpClient } from '../../adapters/http';
 import { API_DEFAULTS, EMOJIS } from '../../config';
 import { Profile } from '../../config/types';
@@ -99,13 +102,20 @@ export class SurveysService extends BaseService {
   async getSurveyByUuid(surveyUuid: string): Promise<SurveyItem> {
     log.info(`${EMOJIS.LOADING} Fetching survey by UUID: ${surveyUuid}...`);
 
-    const response = await this.httpClient.request<SurveyItem>({
-      method: 'GET',
-      url: SURVEYS_ENDPOINTS.SURVEY_BY_ID(surveyUuid),
-    });
+    try {
+      const response = await this.httpClient.request<SurveyItem>({
+        method: 'GET',
+        url: SURVEYS_ENDPOINTS.SURVEY_BY_ID(surveyUuid),
+      });
 
-    log.info(`${EMOJIS.SUCCESS} Retrieved survey "${response.name}" for UUID "${surveyUuid}"`);
-    return response;
+      log.info(`${EMOJIS.SUCCESS} Retrieved survey "${response.name}" for UUID "${surveyUuid}"`);
+      return response;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        throw new ValidationError(`No survey found with UUID: "${surveyUuid}"`);
+      }
+      throw error;
+    }
   }
 
   /**

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -89,18 +89,18 @@ export class SurveysService extends BaseService {
   }
 
   /**
-   * Get surveys by name (returns list of matching surveys)
+   * Get surveys by name
    */
   async getSurveyByName(surveyName: string): Promise<SurveyItem[]> {
     log.info(`${EMOJIS.LOADING} Getting surveys by name: "${surveyName}"...`);
 
-    const matchingSurveys = await this.getAllSurveys({ q: surveyName });
+    const response = await this.getAllSurveys({ q: surveyName });
 
-    if (matchingSurveys.length === 0) {
+    if (response.length === 0) {
       throw new ValidationError(`No survey program found with name: "${surveyName}"`);
     }
 
-    return matchingSurveys;
+    return response;
   }
 
   /**
@@ -109,20 +109,33 @@ export class SurveysService extends BaseService {
   async getSurveyByUuid(surveyUuid: string): Promise<SurveyItem> {
     log.info(`${EMOJIS.LOADING} Fetching survey by UUID: ${surveyUuid}...`);
 
+    const notFoundErrorMessage = `No survey program found with UUID: "${surveyUuid}"`;
+
+    let response: SurveyItem;
     try {
-      const response = await this.httpClient.request<SurveyItem>({
+      response = await this.httpClient.request<SurveyItem>({
         method: 'GET',
         url: SURVEYS_ENDPOINTS.SURVEY_BY_ID(surveyUuid),
       });
-
-      log.info(`${EMOJIS.SUCCESS} Retrieved survey "${response.name}" for UUID "${surveyUuid}"`);
-      return response;
     } catch (error) {
+      log.error(
+        `Error fetching survey by UUID: ${surveyUuid}`,
+        error instanceof Error ? error.message : error
+      );
       if (axios.isAxiosError(error) && error.response?.status === 404) {
-        throw new ValidationError(`No survey program found with UUID: "${surveyUuid}"`);
+        throw new ValidationError(notFoundErrorMessage);
       }
       throw error;
     }
+
+    // Some UUIDs (e.g., ".", "#") cause the URL to be altered and the API returns 200 with an empty
+    // response instead of 404, so check for a valid name to detect when the survey is not found.
+    if (response.name == null) {
+      log.error(`Survey with UUID "${surveyUuid}" not found (empty response)`);
+      throw new ValidationError(notFoundErrorMessage);
+    }
+    log.info(`${EMOJIS.SUCCESS} Retrieved survey "${response.name}" for UUID "${surveyUuid}"`);
+    return response;
   }
 
   /**
@@ -131,16 +144,30 @@ export class SurveysService extends BaseService {
   async getSurveyFlatView(surveyUuid: string): Promise<SurveyFlatViewResponse> {
     log.info(`${EMOJIS.LOADING} Fetching flat view for survey UUID: ${surveyUuid}...`);
 
-    const response = await this.httpClient.request<SurveyFlatViewResponse>({
-      method: 'GET',
-      url: SURVEYS_ENDPOINTS.FLAT_VIEW(surveyUuid),
-    });
+    try {
+      const response = await this.httpClient.request<SurveyFlatViewResponse>({
+        method: 'GET',
+        url: SURVEYS_ENDPOINTS.FLAT_VIEW(surveyUuid),
+      });
 
-    log.info(`${EMOJIS.SUCCESS} Retrieved flat view for survey UUID: ${surveyUuid}`);
-    return response;
+      log.info(`${EMOJIS.SUCCESS} Retrieved flat view for survey UUID: ${surveyUuid}`);
+      return response;
+    } catch (error) {
+      log.error(
+        `Error fetching flat view for survey UUID: ${surveyUuid}`,
+        error instanceof Error ? error.message : error
+      );
+      if (axios.isAxiosError(error) && error.response?.status === 404) {
+        throw new ValidationError(`No survey spec found for survey UUID: "${surveyUuid}"`);
+      }
+      throw error;
+    }
   }
 
-  buildWhereUsedMap(surveyName: string, surveyFlatViewResponse: SurveyFlatViewResponse): Map<string, WhereUsedInfo> {
+  buildWhereUsedMap(
+    surveyName: string,
+    surveyFlatViewResponse: SurveyFlatViewResponse
+  ): Map<string, WhereUsedInfo> {
     const whereUsedMap = new Map<string, WhereUsedInfo>();
 
     // O(1) lookup maps — built once, used by all resolve functions
@@ -148,116 +175,108 @@ export class SurveysService extends BaseService {
     const surveyModelByFieldId = new Map<string, SurveyModelItem>();
     const surveyModelByTranslationKey = new Map<string, SurveyModelItem>();
     surveyFlatViewResponse.survey_model.forEach(item => {
-      if (item.id) surveyModelMap.set(item.id, item);
-      if (item.field?.id) surveyModelByFieldId.set(item.field.id, item);
+      if (item.id) {
+        surveyModelMap.set(item.id, item);
+      }
+      if (item.field?.id) {
+        surveyModelByFieldId.set(item.field.id, item);
+      }
       item.translation_keys?.forEach(tk => {
-        if (tk['translation-key']) surveyModelByTranslationKey.set(tk['translation-key'], item);
+        if (tk['translation-key']) {
+          surveyModelByTranslationKey.set(tk['translation-key'], item);
+        }
       });
     });
 
     const questionFieldByTranslationKey = new Map<string, QuestionField>();
     const questionFieldByAltSetId = new Map<string, QuestionField>();
     surveyFlatViewResponse.question_fields.forEach(qf => {
-      if (qf.translation_key) questionFieldByTranslationKey.set(qf.translation_key, qf);
-      if (qf.alternative_set?.id) questionFieldByAltSetId.set(qf.alternative_set.id, qf);
+      if (qf.translation_key) {
+        questionFieldByTranslationKey.set(qf.translation_key, qf);
+      }
+      if (qf.alternative_set?.id) {
+        questionFieldByAltSetId.set(qf.alternative_set.id, qf);
+      }
     });
 
-    const alternativeByTranslationKey = new Map<string, { alt: AlternativeItem; altSet: AlternativeSet }>();
+    const alternativeByTranslationKey = new Map<
+      string,
+      { alt: AlternativeItem; altSet: AlternativeSet }
+    >();
     surveyFlatViewResponse.alternative_sets.forEach(altSet => {
       altSet.alternatives?.forEach(alt => {
-        if (alt.translation_key) alternativeByTranslationKey.set(alt.translation_key, { alt, altSet });
+        if (alt.translation_key) {
+          alternativeByTranslationKey.set(alt.translation_key, { alt, altSet });
+        }
       });
     });
 
-    const resolve = (key: string): WhereUsedInfo => {
-      if (key.startsWith(':question:')) {
-        return resolveQuestionKey(key);
+    // Joins location path segments, skipping empty ones (e.g. when containerPath is '').
+    const buildLocation = (...parts: string[]): string => parts.filter(Boolean).join(' > ');
+
+    // Builds a display name for a single node in the container chain.
+    // Returns { name, isRootPage } — isRootPage=true signals the walk should stop.
+    const buildPathElement = (item: SurveyModelItem): { name: string; isRootPage: boolean } => {
+      const position = (item.position ?? 0) + 1;
+
+      // Root-level page: type "section" whose own container is the virtual "model" root
+      if (item.type?.toLowerCase() === 'section' && item.container?.id?.toLowerCase() === 'model') {
+        let pageName = `Page ${String(position).padStart(2, '0')}`;
+        if (
+          item.name?.trim() &&
+          item.name.toLowerCase() !== 'page' &&
+          item.name.toLowerCase() !== 'new page'
+        ) {
+          pageName = `${pageName} - ${item.name}`;
+        }
+        return { name: pageName, isRootPage: true };
       }
-      if (key.startsWith(':alternative:')) {
-        return resolveAlternativeKey(key);
+
+      switch (item.type?.toLowerCase()) {
+        case 'section':
+          return {
+            name: item.name || `Section ${String(position).padStart(2, '0')}`,
+            isRootPage: false,
+          };
+        case 'end-section': {
+          let name = `Page ${String(position).padStart(2, '0')}`;
+          if (item.name?.trim() && item.name !== 'Page' && item.name !== 'New Page') {
+            name = `${name} - ${item.name}`;
+          }
+          return { name, isRootPage: false };
+        }
+        default: {
+          const label = item.type
+            ? item.type.charAt(0).toUpperCase() + item.type.slice(1)
+            : 'Container';
+          return { name: `${label} ${String(position).padStart(2, '0')}`, isRootPage: false };
+        }
       }
-      if (key.startsWith(':survey_program:')) {
-        return resolveSurveyProgramKey(key);
-      }
-      return { location: 'Unknown Location', type: 'unknown' };
     };
 
-    // 1. :question: resolution
-    const resolveQuestionKey = (key: string): WhereUsedInfo => {
-      const questionField = questionFieldByTranslationKey.get(key);
-      if (!questionField?.key) {
-        return { location: 'Unknown Question Location', type: 'question' };
+    // Walks the container.id chain upward and returns a ' > '-joined path string.
+    // Returns '' when the element sits directly at the survey root (container is 'model').
+    const buildContainerPath = (containerId: string | undefined): string => {
+      if (!containerId || containerId.toLowerCase() === 'model') {
+        return '';
       }
 
-      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
-      if (!surveyModelElement) {
-        return { location: 'Unknown Question Location', type: 'question' };
+      const path: string[] = [];
+      let current: SurveyModelItem | undefined = surveyModelMap.get(containerId);
+
+      while (current) {
+        const { name, isRootPage } = buildPathElement(current);
+        path.unshift(name);
+        if (isRootPage) {
+          break;
+        }
+        const parentId = current.container?.id;
+        current = parentId ? surveyModelMap.get(parentId) : undefined;
       }
 
-      // Use survey_model[].position for Question numbering (position+1)
-      const questionNumber = (surveyModelElement.position ?? 0) + 1;
-
-      // Walk container.id chain upward to build full path including grids and sections
-      const containerPath = buildContainerPath(surveyModelElement.container?.id);
-
-      return {
-        location: `${surveyName} > ${containerPath} > Question ${String(questionNumber).padStart(2, '0')}`,
-        type: 'question',
-      };
+      return path.join(' > ');
     };
 
-    // 2. :alternative: resolution
-    const resolveAlternativeKey = (key: string): WhereUsedInfo => {
-      const altEntry = alternativeByTranslationKey.get(key);
-      if (!altEntry) {
-        return { location: 'Unknown Answer Location', type: 'alternative' };
-      }
-
-      const { alt: foundAlternative, altSet: foundAlternativeSet } = altEntry;
-      const answerNumber = (foundAlternative.sequence_number ?? 0) + 1;
-
-      const questionField = questionFieldByAltSetId.get(foundAlternativeSet.id);
-      if (!questionField?.key) {
-        return { location: `Answer ${String(answerNumber).padStart(2, '0')}`, type: 'alternative' };
-      }
-
-      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
-      if (!surveyModelElement) {
-        return { location: `Answer ${String(answerNumber).padStart(2, '0')}`, type: 'alternative' };
-      }
-
-      const questionNumber = (surveyModelElement.position ?? 0) + 1;
-
-      // Walk container.id chain upward to build full path
-      const containerPath = buildContainerPath(surveyModelElement.container?.id);
-
-      return {
-        location: `${surveyName} > ${containerPath} > Question ${String(questionNumber).padStart(2, '0')} > Answer ${String(answerNumber).padStart(2, '0')}`,
-        type: 'alternative',
-      };
-    };
-
-    // 3. :survey_program: resolution
-    const resolveSurveyProgramKey = (key: string): WhereUsedInfo => {
-      const foundElement = surveyModelByTranslationKey.get(key);
-      if (!foundElement) {
-        return { location: 'Unknown Survey Program Location', type: 'unknown' };
-      }
-
-      // Check type and determine element type
-      const elementType = getElementTypeName(foundElement.type);
-      const elementNumber = (foundElement.position ?? 0) + 1;
-
-      // Walk up containers to build full path
-      const containerPath = buildContainerPath(foundElement.container?.id);
-
-      return {
-        location: `${surveyName} > ${containerPath} > ${elementType} ${String(elementNumber).padStart(2, '0')}`,
-        type: foundElement.type,
-      };
-    };
-
-    // Helper to get element type name
     const getElementTypeName = (type: string | undefined): string => {
       switch (type?.toLowerCase()) {
         case 'text':
@@ -273,86 +292,95 @@ export class SurveysService extends BaseService {
       }
     };
 
-    // Helper to build container path with improved logic
-    const buildContainerPath = (containerId: string | undefined): string => {
-      if (!containerId) {
-        return 'Unknown Page';
+    // 1. :question: resolution
+    const resolveQuestionKey = (key: string): WhereUsedInfo => {
+      const questionField = questionFieldByTranslationKey.get(key);
+      if (!questionField?.key) {
+        return { location: null, type: 'question' };
       }
 
-      const path: string[] = [];
-      let currentContainer: SurveyModelItem | undefined = surveyModelMap.get(containerId);
-
-      while (currentContainer) {
-        const pathElement = buildPathElement(currentContainer);
-        if (pathElement.isRootPage) {
-          path.unshift(pathElement.name);
-          break;
-        } else {
-          path.unshift(pathElement.name);
-        }
-
-        // Move up the container chain
-        const parentId = currentContainer.container?.id;
-        currentContainer = parentId ? surveyModelMap.get(parentId) : undefined;
+      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
+      if (!surveyModelElement) {
+        return { location: null, type: 'question' };
       }
 
-      return path.length > 0 ? path.join(' > ') : 'Unknown Page';
+      const questionNumber = (surveyModelElement.position ?? 0) + 1;
+      const containerPath = buildContainerPath(surveyModelElement.container?.id);
+      return {
+        location: buildLocation(
+          surveyName,
+          containerPath,
+          `Question ${String(questionNumber).padStart(2, '0')}`
+        ),
+        type: 'question',
+      };
     };
 
-    // Helper to build individual path elements
-    const buildPathElement = (
-      container: SurveyModelItem
-    ): { name: string; isRootPage: boolean } => {
-      const position = (container.position ?? 0) + 1;
-
-      // Root level page is identified when type == "section" AND container.id == "model"
-      if (
-        container.type?.toLowerCase() === 'section' &&
-        container.container?.id?.toLowerCase() === 'model'
-      ) {
-        let pageName = `Page ${String(position).padStart(2, '0')}`;
-
-        // Add meaningful name if available
-        if (
-          container.name?.trim() &&
-          container.name.toLowerCase() !== 'page' &&
-          container.name.toLowerCase() !== 'new page'
-        ) {
-          pageName = `${pageName} - ${container.name}`;
-        }
-
-        return { name: pageName, isRootPage: true };
+    // 2. :alternative: resolution
+    const resolveAlternativeKey = (key: string): WhereUsedInfo => {
+      const altEntry = alternativeByTranslationKey.get(key);
+      if (!altEntry) {
+        return { location: null, type: 'alternative' };
       }
 
-      // Handle other container types
-      switch (container.type?.toLowerCase()) {
-        case 'section':
-          // Nested section
-          return {
-            name: container.name || `Section ${String(position).padStart(2, '0')}`,
-            isRootPage: false,
-          };
-        case 'end-section': {
-          // End section
-          let endSectionName = `Page ${String(position).padStart(2, '0')}`;
-          if (
-            container.name?.trim() &&
-            container.name !== 'Page' &&
-            container.name !== 'New Page'
-          ) {
-            endSectionName = `${endSectionName} - ${container.name}`;
-          }
-          return { name: endSectionName, isRootPage: false };
-        }
-        default: {
-          // Other containers (Grid, etc.)
-          const containerType = container.type.charAt(0).toUpperCase() + container.type.slice(1);
-          return {
-            name: `${containerType} ${String(position).padStart(2, '0')}`,
-            isRootPage: false,
-          };
-        }
+      const { alt: foundAlternative, altSet: foundAlternativeSet } = altEntry;
+      const answerNumber = (foundAlternative.sequence_number ?? 0) + 1;
+      const answerLabel = `Answer ${String(answerNumber).padStart(2, '0')}`;
+
+      const questionField = questionFieldByAltSetId.get(foundAlternativeSet.id);
+      if (!questionField?.key) {
+        return { location: answerLabel, type: 'alternative' };
       }
+
+      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
+      if (!surveyModelElement) {
+        return { location: answerLabel, type: 'alternative' };
+      }
+
+      const questionNumber = (surveyModelElement.position ?? 0) + 1;
+      const containerPath = buildContainerPath(surveyModelElement.container?.id);
+      return {
+        location: buildLocation(
+          surveyName,
+          containerPath,
+          `Question ${String(questionNumber).padStart(2, '0')}`,
+          answerLabel
+        ),
+        type: 'alternative',
+      };
+    };
+
+    // 3. :survey_program: resolution
+    const resolveSurveyProgramKey = (key: string): WhereUsedInfo => {
+      const foundElement = surveyModelByTranslationKey.get(key);
+      if (!foundElement) {
+        return { location: null, type: 'unknown' };
+      }
+
+      const elementType = getElementTypeName(foundElement.type);
+      const elementNumber = (foundElement.position ?? 0) + 1;
+      const containerPath = buildContainerPath(foundElement.container?.id);
+      return {
+        location: buildLocation(
+          surveyName,
+          containerPath,
+          `${elementType} ${String(elementNumber).padStart(2, '0')}`
+        ),
+        type: foundElement.type,
+      };
+    };
+
+    const resolve = (key: string): WhereUsedInfo => {
+      if (key.startsWith(':question:')) {
+        return resolveQuestionKey(key);
+      }
+      if (key.startsWith(':alternative:')) {
+        return resolveAlternativeKey(key);
+      }
+      if (key.startsWith(':survey_program:')) {
+        return resolveSurveyProgramKey(key);
+      }
+      return { location: null, type: 'unknown' };
     };
 
     // Pre-build the map by processing all possible translation keys upfront

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -329,12 +329,12 @@ export class SurveysService extends BaseService {
 
       const questionField = questionFieldByAltSetId.get(foundAlternativeSet.id);
       if (!questionField?.key) {
-        return { location: answerLabel, type: 'alternative' };
+        return { location: buildLocation(surveyName, answerLabel), type: 'alternative' };
       }
 
       const surveyModelElement = surveyModelByFieldId.get(questionField.key);
       if (!surveyModelElement) {
-        return { location: answerLabel, type: 'alternative' };
+        return { location: buildLocation(surveyName, answerLabel), type: 'alternative' };
       }
 
       const questionNumber = (surveyModelElement.position ?? 0) + 1;

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -94,13 +94,13 @@ export class SurveysService extends BaseService {
   async getSurveyByName(surveyName: string): Promise<SurveyItem[]> {
     log.info(`${EMOJIS.LOADING} Getting surveys by name: "${surveyName}"...`);
 
-    const allSurveys = await this.getAllSurveys({ q: surveyName });
+    const matchingSurveys = await this.getAllSurveys({ q: surveyName });
 
-    if (allSurveys.length === 0) {
+    if (matchingSurveys.length === 0) {
       throw new ValidationError(`No survey program found with name: "${surveyName}"`);
     }
 
-    return allSurveys;
+    return matchingSurveys;
   }
 
   /**

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -84,6 +84,11 @@ export class SurveysService extends BaseService {
     }
 
     log.info(`${EMOJIS.SUCCESS} Retrieved all ${allSurveys.length} surveys`);
+
+    if (allSurveys.length === 0) {
+      throw new ValidationError(`No survey program found with name: "${options?.q}"`);
+    }
+
     return allSurveys;
   }
 
@@ -112,7 +117,7 @@ export class SurveysService extends BaseService {
       return response;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.status === 404) {
-        throw new ValidationError(`No survey found with UUID: "${surveyUuid}"`);
+        throw new ValidationError(`No survey program found with UUID: "${surveyUuid}"`);
       }
       throw error;
     }
@@ -136,12 +141,30 @@ export class SurveysService extends BaseService {
   buildWhereUsedMap(surveyName: string, surveyFlatViewResponse: SurveyFlatViewResponse): Map<string, WhereUsedInfo> {
     const whereUsedMap = new Map<string, WhereUsedInfo>();
 
-    // Create lookup maps for better performance
+    // O(1) lookup maps — built once, used by all resolve functions
     const surveyModelMap = new Map<string, SurveyModelItem>();
+    const surveyModelByFieldId = new Map<string, SurveyModelItem>();
+    const surveyModelByTranslationKey = new Map<string, SurveyModelItem>();
     surveyFlatViewResponse.survey_model.forEach(item => {
-      if (item.id) {
-        surveyModelMap.set(item.id, item);
-      }
+      if (item.id) surveyModelMap.set(item.id, item);
+      if (item.field?.id) surveyModelByFieldId.set(item.field.id, item);
+      item.translation_keys?.forEach(tk => {
+        if (tk['translation-key']) surveyModelByTranslationKey.set(tk['translation-key'], item);
+      });
+    });
+
+    const questionFieldByTranslationKey = new Map<string, QuestionField>();
+    const questionFieldByAltSetId = new Map<string, QuestionField>();
+    surveyFlatViewResponse.question_fields.forEach(qf => {
+      if (qf.translation_key) questionFieldByTranslationKey.set(qf.translation_key, qf);
+      if (qf.alternative_set?.id) questionFieldByAltSetId.set(qf.alternative_set.id, qf);
+    });
+
+    const alternativeByTranslationKey = new Map<string, { alt: AlternativeItem; altSet: AlternativeSet }>();
+    surveyFlatViewResponse.alternative_sets.forEach(altSet => {
+      altSet.alternatives?.forEach(alt => {
+        if (alt.translation_key) alternativeByTranslationKey.set(alt.translation_key, { alt, altSet });
+      });
     });
 
     const resolve = (key: string): WhereUsedInfo => {
@@ -159,18 +182,12 @@ export class SurveysService extends BaseService {
 
     // 1. :question: resolution
     const resolveQuestionKey = (key: string): WhereUsedInfo => {
-      // Find translation_key in question_fields[]
-      const questionField = surveyFlatViewResponse.question_fields.find(
-        (qf: QuestionField) => qf.translation_key === key
-      );
+      const questionField = questionFieldByTranslationKey.get(key);
       if (!questionField?.key) {
         return { location: 'Unknown Question Location', type: 'question' };
       }
 
-      // Get field key and match against survey_model[].field.id
-      const surveyModelElement = surveyFlatViewResponse.survey_model.find(
-        (sm: SurveyModelItem) => sm.field?.id === questionField.key
-      );
+      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
       if (!surveyModelElement) {
         return { location: 'Unknown Question Location', type: 'question' };
       }
@@ -189,40 +206,20 @@ export class SurveysService extends BaseService {
 
     // 2. :alternative: resolution
     const resolveAlternativeKey = (key: string): WhereUsedInfo => {
-      // Match the key with alternative_sets[].alternatives[].translation_key
-      let foundAlternative: AlternativeItem | null = null;
-      let foundAlternativeSet: AlternativeSet | null = null;
-
-      for (const altSet of surveyFlatViewResponse.alternative_sets) {
-        if (altSet.alternatives) {
-          const alt = altSet.alternatives.find((a: AlternativeItem) => a.translation_key === key);
-          if (alt) {
-            foundAlternative = alt;
-            foundAlternativeSet = altSet;
-            break;
-          }
-        }
-      }
-
-      if (!foundAlternative || !foundAlternativeSet) {
+      const altEntry = alternativeByTranslationKey.get(key);
+      if (!altEntry) {
         return { location: 'Unknown Answer Location', type: 'alternative' };
       }
 
-      // Get sequence_number → Answer numbering (sequence_number+1)
+      const { alt: foundAlternative, altSet: foundAlternativeSet } = altEntry;
       const answerNumber = (foundAlternative.sequence_number ?? 0) + 1;
 
-      // Get the alternative id, match to question_fields[].alternative_set.id
-      const questionField = surveyFlatViewResponse.question_fields.find(
-        (qf: QuestionField) => qf.alternative_set?.id === foundAlternativeSet.id
-      );
+      const questionField = questionFieldByAltSetId.get(foundAlternativeSet.id);
       if (!questionField?.key) {
         return { location: `Answer ${String(answerNumber).padStart(2, '0')}`, type: 'alternative' };
       }
 
-      // Match to survey_model[].field.id for Question numbering
-      const surveyModelElement = surveyFlatViewResponse.survey_model.find(
-        (sm: SurveyModelItem) => sm.field?.id === questionField.key
-      );
+      const surveyModelElement = surveyModelByFieldId.get(questionField.key);
       if (!surveyModelElement) {
         return { location: `Answer ${String(answerNumber).padStart(2, '0')}`, type: 'alternative' };
       }
@@ -240,19 +237,7 @@ export class SurveysService extends BaseService {
 
     // 3. :survey_program: resolution
     const resolveSurveyProgramKey = (key: string): WhereUsedInfo => {
-      // Match key with survey_model[].translation_keys[].translation-key
-      let foundElement: SurveyModelItem | null = null;
-
-      for (const element of surveyFlatViewResponse.survey_model) {
-        if (element.translation_keys) {
-          const matchingKey = element.translation_keys.find(tk => tk['translation-key'] === key);
-          if (matchingKey) {
-            foundElement = element;
-            break;
-          }
-        }
-      }
-
+      const foundElement = surveyModelByTranslationKey.get(key);
       if (!foundElement) {
         return { location: 'Unknown Survey Program Location', type: 'unknown' };
       }

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -130,8 +130,8 @@ export class SurveysService extends BaseService {
 
     // Some UUIDs (e.g., ".", "#") cause the URL to be altered and the API returns 200 with an empty
     // response instead of 404, so check for a valid name to detect when the survey is not found.
-    if (response.name == null) {
-      log.error(`Survey with UUID "${surveyUuid}" not found (empty response)`);
+    if (!response || typeof response !== 'object' || response.name == null) {
+      log.error(`Survey with UUID "${surveyUuid}" not found (empty or invalid response)`);
       throw new ValidationError(notFoundErrorMessage);
     }
     log.info(`${EMOJIS.SUCCESS} Retrieved survey "${response.name}" for UUID "${surveyUuid}"`);

--- a/src/core/services/surveys/surveys-service.ts
+++ b/src/core/services/surveys/surveys-service.ts
@@ -85,10 +85,6 @@ export class SurveysService extends BaseService {
 
     log.info(`${EMOJIS.SUCCESS} Retrieved all ${allSurveys.length} surveys`);
 
-    if (allSurveys.length === 0) {
-      throw new ValidationError(`No survey program found with name: "${options?.q}"`);
-    }
-
     return allSurveys;
   }
 
@@ -98,7 +94,13 @@ export class SurveysService extends BaseService {
   async getSurveyByName(surveyName: string): Promise<SurveyItem[]> {
     log.info(`${EMOJIS.LOADING} Getting surveys by name: "${surveyName}"...`);
 
-    return this.getAllSurveys({ q: surveyName });
+    const allSurveys = await this.getAllSurveys({ q: surveyName });
+
+    if (allSurveys.length === 0) {
+      throw new ValidationError(`No survey program found with name: "${surveyName}"`);
+    }
+
+    return allSurveys;
   }
 
   /**

--- a/src/core/services/surveys/types.ts
+++ b/src/core/services/surveys/types.ts
@@ -116,12 +116,6 @@ export interface WhereUsedInfo {
   type: string;
 }
 
-export interface WhereUsedMap {
-  get(key: string): WhereUsedInfo;
-  has(key: string): boolean;
-  forEach(fn: (value: WhereUsedInfo, key: string) => void): void;
-}
-
 export interface WhereUsedAccumulator {
   locations: Set<string>;
   type: string;

--- a/src/core/services/surveys/types.ts
+++ b/src/core/services/surveys/types.ts
@@ -106,7 +106,7 @@ export interface AlternativeSet {
 }
 
 export interface WhereUsedInfo {
-  location: string;
+  location: string | null; // null = could not be resolved for this survey
   // Available types for survey_program:
   // section, cookie-confirmation, trip-advisor, trip-advisor-external-widget,
   // end-section, text, image, grid, date-picker, media-question, file-upload-question,
@@ -120,4 +120,9 @@ export interface WhereUsedMap {
   get(key: string): WhereUsedInfo;
   has(key: string): boolean;
   forEach(fn: (value: WhereUsedInfo, key: string) => void): void;
+}
+
+export interface WhereUsedAccumulator {
+  locations: Set<string>;
+  type: string;
 }

--- a/src/core/services/translations/constants.ts
+++ b/src/core/services/translations/constants.ts
@@ -10,7 +10,7 @@ export const TRANSLATIONS_ENDPOINTS = {
 } as const;
 
 export const FILE_PROCESSING = {
-  EXCEL_SHEET_NAME: 'Translations (v1)',
+  EXCEL_SHEET_NAME: 'Translations (v1.2)',
   RAW_TRANSLATIONS_SUFFIX: 'raw-translations',
   PROCESSED_TRANSLATIONS_SUFFIX: 'processed-translations',
   SURVEY_SPEC_SUFFIX: 'survey-spec',

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -514,6 +514,7 @@ export class TranslationsService extends BaseService {
           method: 'GET',
           url: TRANSLATIONS_ENDPOINTS.IMPORT_CHANGES(importId),
         });
+        this.normalizeAndDeduplicateChanges(changes);
         this.cleanupTempFile(processedFilePath, isDebugEnabled);
         return changes;
       }
@@ -528,6 +529,43 @@ export class TranslationsService extends BaseService {
       this.cleanupTempFile(processedFilePath, isDebugEnabled);
       throw error;
     }
+  }
+
+  /**
+   * Normalizes and deduplicates a changes response in-place.
+   *
+   * When a user edits a translation item once in the Excel file, the upload
+   * process programmatically applies that edit to multiple context rows:
+   *   - "In survey"        → maps to the survey-only.surv    context
+   *   - "In mobile survey" → maps to the survey-only.survMobile context
+   *
+   * This means the API returns one change entry per context variant, so a
+   * single user edit can appear 2+ times in the changes list. To avoid
+   * showing the same logical change multiple times, we deduplicate by the
+   * combination of (translation_item key, locale_id) — which uniquely
+   * identifies one translation string for one language, regardless of context.
+   */
+  private normalizeAndDeduplicateChanges(changes: TranslationImportChangesResponse): void {
+    const seen = new Set<string>();
+    const uniqueItems: TranslationImportChangesResponse['items'] = [];
+
+    for (const item of changes.items) {
+      // Resolve the locale UUID from the linked locale resource URL
+      const localeHref = item._links?.translation_locale?.href ?? '';
+      item.locale_id = localeHref.split('/').pop() || 'unknown';
+
+      // Deduplicate: one entry per (translation item key × locale)
+      const translationItemHref = item._links?.translation_item?.href ?? item.id;
+      const dedupeKey = `${translationItemHref}|${item.locale_id}`;
+
+      if (!seen.has(dedupeKey)) {
+        seen.add(dedupeKey);
+        uniqueItems.push(item);
+      }
+    }
+
+    changes.items = uniqueItems;
+    changes._total = uniqueItems.length;
   }
 
   /**

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -285,7 +285,10 @@ export class TranslationsService extends BaseService {
       const combinedWhereUsedMap = new Map<string, WhereUsedInfo>(
         [...accumulator.entries()].map(([key, value]) => [
           key,
-          { location: [...value.locations].join(',\n'), type: value.type },
+          {
+            location: value.locations.size > 0 ? [...value.locations].join(',\n') : null,
+            type: value.type,
+          },
         ])
       );
 
@@ -608,6 +611,9 @@ export class TranslationsService extends BaseService {
       await outputWorkbook.xlsx.writeFile(outputFilePath);
       return outputFilePath;
     } catch (e) {
+      if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENAMETOOLONG') {
+        throw new ValidationError("The file name is too long. Try using a shorter file name.");
+      }
       log.error(`${EMOJIS.ERROR} Error processing file for upload: ${String(e)}`);
       throw e;
     }

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -612,7 +612,7 @@ export class TranslationsService extends BaseService {
       return outputFilePath;
     } catch (e) {
       if (e instanceof Error && (e as NodeJS.ErrnoException).code === 'ENAMETOOLONG') {
-        throw new ValidationError("The file name is too long. Try using a shorter file name.");
+        throw new ValidationError('The file name is too long. Try using a shorter file name.');
       }
       log.error(`${EMOJIS.ERROR} Error processing file for upload: ${String(e)}`);
       throw e;

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -9,7 +9,7 @@ import { API_DEFAULTS, EMOJIS, ERROR_CODES, FILE_EXTENSIONS } from '../../config
 import { Profile } from '../../config/types';
 import { BaseService } from '../base';
 import { SurveysService } from '../surveys';
-import { SurveyFlatViewResponse, WhereUsedInfo } from '../surveys/types';
+import { SurveyFlatViewResponse, WhereUsedInfo, WhereUsedAccumulator } from '../surveys/types';
 
 import { TRANSLATIONS_ENDPOINTS, TRANSLATIONS_STATUS, FILE_PROCESSING } from './constants';
 import {
@@ -44,7 +44,7 @@ export class TranslationsService extends BaseService {
     log.info(
       `${EMOJIS.LOADING} Downloading translations for survey(s): ${options.surveys.map(survey => `${survey.name} (${survey.id})`).join(', ')} ${isDebugEnabled ? '(Debug mode enabled)' : ''}`
     );
-    
+
     for (const survey of options.surveys) {
       if (survey.translation_tag_id === null) {
         log.error(
@@ -61,7 +61,9 @@ export class TranslationsService extends BaseService {
       data: {
         type: 'translation-export',
         file_format: 'excel',
-        translation_tag_ids: options.surveys.map(survey => ({ id: `${survey.translation_tag_id}` })),
+        translation_tag_ids: options.surveys.map(survey => ({
+          id: `${survey.translation_tag_id}`,
+        })),
         translation_locale_ids: [],
         translation_categories: [
           'questions',
@@ -85,7 +87,9 @@ export class TranslationsService extends BaseService {
       'Export'
     );
 
-    const flatViewPromises = options.surveys.map(survey => this.surveysService.getSurveyFlatView(survey.id));
+    const flatViewPromises = options.surveys.map(survey =>
+      this.surveysService.getSurveyFlatView(survey.id)
+    );
 
     // Wait for both operations to complete
     const [, surveyFlatViewResponses] = await Promise.all([
@@ -101,10 +105,11 @@ export class TranslationsService extends BaseService {
     const isMultiSurvey = options.surveys.length > 1;
     const rawSurveyIdsPart = options.surveys.map(survey => survey.id).join('_');
     // Truncate survey IDs part if it's too long to avoid file system 255 character limit issues (considering additional suffixes and extensions)
-    const truncatedSurveyIdsPart = rawSurveyIdsPart.length > 200
-      ? rawSurveyIdsPart.slice(0, 200)
-      : rawSurveyIdsPart;
-    const surveyIdsPart = isMultiSurvey ? `${truncatedSurveyIdsPart}-multi` : truncatedSurveyIdsPart;
+    const truncatedSurveyIdsPart =
+      rawSurveyIdsPart.length > 200 ? rawSurveyIdsPart.slice(0, 200) : rawSurveyIdsPart;
+    const surveyIdsPart = isMultiSurvey
+      ? `${truncatedSurveyIdsPart}-multi`
+      : truncatedSurveyIdsPart;
     const simplifiedTranslationsFileName = `${surveyIdsPart}-${timestamp}${FILE_EXTENSIONS.EXCEL}`;
     const simplifiedTranslationsFilePath = PathUtils.join(
       options.outputPath,
@@ -246,39 +251,43 @@ export class TranslationsService extends BaseService {
         throw new ValidationError('Required columns (Key, Original text) not found');
       }
 
-      // Build "Where Used" mapping using pre-fetched data with survey names
-      // Combine all whereUsed maps into a single map
-      const combinedWhereUsedMap = new Map<string, WhereUsedInfo>();
-      const keyLocationMap = new Map<string, { locations: Set<string>, type?: string }>();
+      // Build combined "Where Used" map across all surveys.
+      // For each key: accumulate all non-unknown location strings (deduped via Set)
+      // and resolve the effective type, where 'html' takes priority so that the
+      // includeHtmlBlocks filter is applied correctly even across multiple surveys.
+      const accumulator = new Map<string, WhereUsedAccumulator>();
 
-      surveyFlatViewResponses.forEach((surveyFlatViewResponse, index) => {
+      for (const [index, surveyFlatViewResponse] of surveyFlatViewResponses.entries()) {
         const surveyName = options.surveys[index].name;
-        const whereUsedMap = this.surveysService.buildWhereUsedMap(surveyName, surveyFlatViewResponse);
-        
-        // Process each key from the pre-built map
-        whereUsedMap.forEach((result, key) => {
-          if (!keyLocationMap.has(key)) {
-            keyLocationMap.set(key, { locations: new Set<string>(), type: result.type });
-          } else if (result.type === 'html') {
-            // If any survey reports this key as html, treat the merged entry as html
-            // so the includeHtmlBlocks filter is applied correctly across all surveys
-            keyLocationMap.get(key)!.type = 'html';
-          }
-          // Only include non-unknown locations in the display text, but always
-          // preserve the entry and its type so HTML-block filtering works correctly
-          if (!result.location.includes('Unknown')) {
-            keyLocationMap.get(key)!.locations.add(result.location);
-          }
-        });
-      });
+        const whereUsedMap = this.surveysService.buildWhereUsedMap(
+          surveyName,
+          surveyFlatViewResponse
+        );
 
-      // Build final combined map with joined locations
-      keyLocationMap.forEach((value, key) => {
-        combinedWhereUsedMap.set(key, {
-          location: [...value.locations].join(',\n'),
-          type: value.type || 'unknown'
-        });
-      });
+        for (const [key, result] of whereUsedMap) {
+          const existing = accumulator.get(key);
+          if (!existing) {
+            accumulator.set(key, {
+              locations: new Set(result.location !== null ? [result.location] : []),
+              type: result.type,
+            });
+          } else {
+            if (result.type === 'html') {
+              existing.type = 'html';
+            } // html takes priority over other types
+            if (result.location !== null) {
+              existing.locations.add(result.location);
+            }
+          }
+        }
+      }
+
+      const combinedWhereUsedMap = new Map<string, WhereUsedInfo>(
+        [...accumulator.entries()].map(([key, value]) => [
+          key,
+          { location: [...value.locations].join(',\n'), type: value.type },
+        ])
+      );
 
       // Filter rows
       const filteredRows: (string | number | undefined)[][] = [];
@@ -397,7 +406,7 @@ export class TranslationsService extends BaseService {
           return rowValues[idx] ?? '';
         });
         const row = outputWorksheet.addRow(outputRow);
-        
+
         // Enable text wrapping for the "Where Used" cell to show line breaks
         if (whereUsedColIndex > 0 && whereUsedValue.includes('\n')) {
           row.getCell(whereUsedColIndex).alignment = { wrapText: true, vertical: 'middle' };

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -157,13 +157,12 @@ export class TranslationsService extends BaseService {
       this.cleanupTempFile(rawTranslationsFilePath, isDebugEnabled);
 
       log.info(
-        `${EMOJIS.SUCCESS} Downloaded ${simplifiedTranslationsFilePath.split('/').pop()} translations for survey(s): ${options.surveys.map(s => s.name).join(', ')}`
+        `${EMOJIS.SUCCESS} Downloaded ${PathUtils.basename(simplifiedTranslationsFilePath)} translations for survey(s): ${options.surveys.map(s => s.name).join(', ')}`
       );
 
       return {
         processedFilePath: simplifiedTranslationsFilePath,
         rawTranslationsFilePath: isDebugEnabled ? rawTranslationsFilePath : '',
-        surveySpecFilePath: '',
         missingLanguages,
       };
     } catch (error) {
@@ -579,7 +578,7 @@ export class TranslationsService extends BaseService {
 
       // Generate output file path
       const originalFileName = FileValidator.sanitizeFilename(
-        filePath.split('/').pop() || 'translations.xlsx'
+        PathUtils.basename(filePath) || 'translations.xlsx'
       );
       const originalFileNameWithoutExtension =
         PathUtils.getFileNameWithoutExtension(originalFileName);
@@ -609,7 +608,7 @@ export class TranslationsService extends BaseService {
 
     const formData = new FormData();
     const fileName = FileValidator.sanitizeFilename(
-      filePath.split('/').pop() || 'translations.xlsx'
+      PathUtils.basename(filePath) || 'translations.xlsx'
     );
     formData.append('file', this.fsAdapter.createReadStream(filePath), fileName);
 

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -50,7 +50,7 @@ export class TranslationsService extends BaseService {
         log.error(
           `${EMOJIS.ERROR} Cannot find translation tag ID for survey: ${survey.name} (${survey.id})`
         );
-        return Promise.reject(new ValidationError(`No survey version found for: ${survey.name} (${survey.id})`));
+        throw new ValidationError(`No survey version found for: ${survey.name} (${survey.id})`);
       }
     }
 

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -250,7 +250,7 @@ export class TranslationsService extends BaseService {
       // Build "Where Used" mapping using pre-fetched data with survey names
       // Combine all whereUsed maps into a single map
       const combinedWhereUsedMap = new Map<string, WhereUsedInfo>();
-      const keyLocationMap = new Map<string, { locations: string[], type?: string }>();
+      const keyLocationMap = new Map<string, { locations: Set<string>, type?: string }>();
 
       surveyFlatViewResponses.forEach((surveyFlatViewResponse, index) => {
         const surveyName = options.surveys[index].name;
@@ -258,11 +258,13 @@ export class TranslationsService extends BaseService {
         
         // Process each key from the pre-built map
         whereUsedMap.forEach((result, key) => {
+          if (!keyLocationMap.has(key)) {
+            keyLocationMap.set(key, { locations: new Set<string>(), type: result.type });
+          }
+          // Only include non-unknown locations in the display text, but always
+          // preserve the entry and its type so HTML-block filtering works correctly
           if (!result.location.includes('Unknown')) {
-            if (!keyLocationMap.has(key)) {
-              keyLocationMap.set(key, { locations: [], type: result.type });
-            }
-            keyLocationMap.get(key)!.locations.push(result.location);
+            keyLocationMap.get(key)!.locations.add(result.location);
           }
         });
       });
@@ -270,7 +272,7 @@ export class TranslationsService extends BaseService {
       // Build final combined map with joined locations
       keyLocationMap.forEach((value, key) => {
         combinedWhereUsedMap.set(key, {
-          location: value.locations.join(',\n'),
+          location: [...value.locations].join(',\n'),
           type: value.type || 'unknown'
         });
       });
@@ -330,7 +332,7 @@ export class TranslationsService extends BaseService {
       outputHeaders.splice(1, 0, -1, -2); // Add Where Used and Notes to Translator after Key
       const headerRowWithExtraColumns = outputHeaders.map(idx => {
         if (idx === -1) {
-          return 'Where Used';
+          return 'Where Used (applies to selected surveys only)';
         }
         if (idx === -2) {
           return 'Notes to Translator';

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -259,6 +259,10 @@ export class TranslationsService extends BaseService {
         whereUsedMap.forEach((result, key) => {
           if (!keyLocationMap.has(key)) {
             keyLocationMap.set(key, { locations: new Set<string>(), type: result.type });
+          } else if (result.type === 'html') {
+            // If any survey reports this key as html, treat the merged entry as html
+            // so the includeHtmlBlocks filter is applied correctly across all surveys
+            keyLocationMap.get(key)!.type = 'html';
           }
           // Only include non-unknown locations in the display text, but always
           // preserve the entry and its type so HTML-block filtering works correctly

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -9,7 +9,7 @@ import { API_DEFAULTS, EMOJIS, ERROR_CODES, FILE_EXTENSIONS } from '../../config
 import { Profile } from '../../config/types';
 import { BaseService } from '../base';
 import { SurveysService } from '../surveys';
-import { SurveyFlatViewResponse } from '../surveys/types';
+import { SurveyFlatViewResponse, WhereUsedInfo } from '../surveys/types';
 
 import { TRANSLATIONS_ENDPOINTS, TRANSLATIONS_STATUS, FILE_PROCESSING } from './constants';
 import {
@@ -42,14 +42,16 @@ export class TranslationsService extends BaseService {
   ): Promise<TranslationDownloadResult> {
     const isDebugEnabled = options.saveDebugFiles;
     log.info(
-      `${EMOJIS.LOADING} Downloading translations for survey: ${options.survey.name} (${options.survey.id}) ${isDebugEnabled ? '(Debug mode enabled)' : ''}`
+      `${EMOJIS.LOADING} Downloading translations for survey(s): ${options.surveys.map(survey => `${survey.name} (${survey.id})`).join(', ')} ${isDebugEnabled ? '(Debug mode enabled)' : ''}`
     );
-
-    if (options.survey.translation_tag_id === null) {
-      log.error(
-        `${EMOJIS.ERROR} Cannot find translation tag ID for survey: ${options.survey.name} (${options.survey.id})`
-      );
-      return Promise.reject(new ValidationError('No survey version found'));
+    
+    for (const survey of options.surveys) {
+      if (survey.translation_tag_id === null) {
+        log.error(
+          `${EMOJIS.ERROR} Cannot find translation tag ID for survey: ${survey.name} (${survey.id})`
+        );
+        return Promise.reject(new ValidationError(`No survey version found for: ${survey.name} (${survey.id})`));
+      }
     }
 
     // Start export job
@@ -59,7 +61,7 @@ export class TranslationsService extends BaseService {
       data: {
         type: 'translation-export',
         file_format: 'excel',
-        translation_tag_ids: [{ id: `${options.survey.translation_tag_id}` }],
+        translation_tag_ids: options.surveys.map(survey => ({ id: `${survey.translation_tag_id}` })),
         translation_locale_ids: [],
         translation_categories: [
           'questions',
@@ -83,12 +85,12 @@ export class TranslationsService extends BaseService {
       'Export'
     );
 
-    const flatViewPromise = this.surveysService.getSurveyFlatView(options.survey.id);
+    const flatViewPromises = options.surveys.map(survey => this.surveysService.getSurveyFlatView(survey.id));
 
     // Wait for both operations to complete
-    const [, surveyFlatViewResponse] = await Promise.all([
+    const [, surveyFlatViewResponses] = await Promise.all([
       exportCompletionPromise,
-      flatViewPromise,
+      Promise.all(flatViewPromises),
     ]);
 
     // Generate file paths
@@ -96,24 +98,29 @@ export class TranslationsService extends BaseService {
       .toISOString()
       .replace(/[-:]/g, '')
       .replace(/\.\d{3}/, '');
-    const simplifiedTranslationsFileName = `${options.survey.id}-${timestamp}${FILE_EXTENSIONS.EXCEL}`;
+    const surveyIdsPart = options.surveys.map(survey => survey.id).join('_');
+    const simplifiedTranslationsFileName = `${surveyIdsPart}-${timestamp}${FILE_EXTENSIONS.EXCEL}`;
     const simplifiedTranslationsFilePath = PathUtils.join(
       options.outputPath,
       simplifiedTranslationsFileName
     );
-    const rawTranslationsFileName = `${options.survey.id}-${timestamp}-${FILE_PROCESSING.RAW_TRANSLATIONS_SUFFIX}${FILE_EXTENSIONS.EXCEL}`;
+    const rawTranslationsFileName = `${surveyIdsPart}-${timestamp}-${FILE_PROCESSING.RAW_TRANSLATIONS_SUFFIX}${FILE_EXTENSIONS.EXCEL}`;
     const rawTranslationsFilePath = isDebugEnabled
       ? PathUtils.join(options.outputPath, rawTranslationsFileName)
       : this.fsAdapter.getTempFilePath(rawTranslationsFileName);
-    const surveyFlatViewFileName = `${options.survey.id}-${timestamp}-${FILE_PROCESSING.SURVEY_SPEC_SUFFIX}${FILE_EXTENSIONS.JSON}`;
-    if (isDebugEnabled) {
-      const surveyFlatViewFilePath = PathUtils.join(options.outputPath, surveyFlatViewFileName);
-      this.fsAdapter.writeFileSync(
-        surveyFlatViewFilePath,
-        JSON.stringify(surveyFlatViewResponse, null, 2)
-      );
-      log.info(`${EMOJIS.FILE} Survey spec file saved to: ${surveyFlatViewFilePath}`);
-    }
+
+    options.surveys.forEach((survey, index) => {
+      const surveyFlatViewResponse = surveyFlatViewResponses[index];
+      const surveyFlatViewFileName = `${survey.id}-${timestamp}-${FILE_PROCESSING.SURVEY_SPEC_SUFFIX}${FILE_EXTENSIONS.JSON}`;
+      if (isDebugEnabled) {
+        const surveyFlatViewFilePath = PathUtils.join(options.outputPath, surveyFlatViewFileName);
+        this.fsAdapter.writeFileSync(
+          surveyFlatViewFilePath,
+          JSON.stringify(surveyFlatViewResponse, null, 2)
+        );
+        log.info(`${EMOJIS.FILE} Survey spec file saved to: ${surveyFlatViewFilePath}`);
+      }
+    });
 
     try {
       // Download file
@@ -138,13 +145,13 @@ export class TranslationsService extends BaseService {
         requestedLanguages,
         missingLanguages,
         options,
-        surveyFlatViewResponse
+        surveyFlatViewResponses
       );
 
       this.cleanupTempFile(rawTranslationsFilePath, isDebugEnabled);
 
       log.info(
-        `${EMOJIS.SUCCESS} Downloaded ${simplifiedTranslationsFilePath.split('/').pop()} translations for survey: ${options.survey.name}`
+        `${EMOJIS.SUCCESS} Downloaded ${simplifiedTranslationsFilePath.split('/').pop()} translations for survey(s): ${options.surveys.map(s => s.name).join(', ')}`
       );
 
       return {
@@ -177,7 +184,7 @@ export class TranslationsService extends BaseService {
     languages: string[],
     missingLanguages: string[],
     options: DownloadTranslationsOptions,
-    surveyFlatViewResponse: SurveyFlatViewResponse
+    surveyFlatViewResponses: SurveyFlatViewResponse[]
   ): Promise<string> {
     try {
       // Read input file
@@ -234,8 +241,33 @@ export class TranslationsService extends BaseService {
         throw new ValidationError('Required columns (Key, Original text) not found');
       }
 
-      // Build "Where Used" mapping using pre-fetched data
-      const whereUsedMap = await this.surveysService.buildWhereUsedMap(surveyFlatViewResponse);
+      // Build "Where Used" mapping using pre-fetched data with survey names
+      // Combine all whereUsed maps into a single map
+      const combinedWhereUsedMap = new Map<string, WhereUsedInfo>();
+      const keyLocationMap = new Map<string, { locations: string[], type?: string }>();
+
+      surveyFlatViewResponses.forEach((surveyFlatViewResponse, index) => {
+        const surveyName = options.surveys[index].name;
+        const whereUsedMap = this.surveysService.buildWhereUsedMap(surveyName, surveyFlatViewResponse);
+        
+        // Process each key from the pre-built map
+        whereUsedMap.forEach((result, key) => {
+          if (!result.location.includes('Unknown')) {
+            if (!keyLocationMap.has(key)) {
+              keyLocationMap.set(key, { locations: [], type: result.type });
+            }
+            keyLocationMap.get(key)!.locations.push(result.location);
+          }
+        });
+      });
+
+      // Build final combined map with joined locations
+      keyLocationMap.forEach((value, key) => {
+        combinedWhereUsedMap.set(key, {
+          location: value.locations.join('\n'),
+          type: value.type || 'unknown'
+        });
+      });
 
       // Filter rows
       const filteredRows: (string | number | undefined)[][] = [];
@@ -262,7 +294,7 @@ export class TranslationsService extends BaseService {
             ? (row.getCell(originalTextColIndex + 1).value?.toString() ?? '')
             : '';
         const keyValue = rowValues[keyColIdx]?.toString() ?? '';
-        const whereUsedInfo = whereUsedMap.get(keyValue);
+        const whereUsedInfo = combinedWhereUsedMap.get(keyValue);
 
         // Skip blank rows
         if (originalTextValue.trim().toLowerCase() === '[blank]') {
@@ -329,14 +361,21 @@ export class TranslationsService extends BaseService {
         column.width = Math.max(headerLength + 2, 12);
       });
 
+      // Set wider width for "Where Used" column to accommodate multi-line content
+      const whereUsedColIndex = outputHeaders.indexOf(-1) + 1;
+      if (whereUsedColIndex > 0) {
+        outputWorksheet.getColumn(whereUsedColIndex).width = 50;
+      }
+
       // Add data rows
       filteredRows.forEach(rowValues => {
         const keyValue = rowValues[keyColIdx]?.toString() ?? '';
         const originalTextValue = rowValues[originalTextColIndex]?.toString() ?? '';
 
-        const whereUsedInfo = whereUsedMap.get(keyValue);
+        const whereUsedInfo = combinedWhereUsedMap.get(keyValue);
         const whereUsedValue = whereUsedInfo?.location || '';
-        const notesToTranslator = this.generateNotesToTranslator(originalTextValue);
+        const usedInMultiplePlaces = whereUsedValue.includes('\n');
+        const notesToTranslator = this.generateNotesToTranslator(originalTextValue, usedInMultiplePlaces);
 
         const outputRow = outputHeaders.map(idx => {
           if (idx === -1) {
@@ -347,7 +386,12 @@ export class TranslationsService extends BaseService {
           }
           return rowValues[idx] ?? '';
         });
-        outputWorksheet.addRow(outputRow);
+        const row = outputWorksheet.addRow(outputRow);
+        
+        // Enable text wrapping for the "Where Used" cell to show line breaks
+        if (whereUsedColIndex > 0 && whereUsedValue.includes('\n')) {
+          row.getCell(whereUsedColIndex).alignment = { wrapText: true, vertical: 'middle' };
+        }
       });
 
       await outputWorkbook.xlsx.writeFile(outputFilePath);
@@ -361,23 +405,32 @@ export class TranslationsService extends BaseService {
   /**
    * Generate notes to translator based on text content
    */
-  private generateNotesToTranslator(text: string): string {
+  private generateNotesToTranslator(text: string, usedInMultiplePlaces: boolean): string {
     if (!text) {
       return '';
     }
 
     const hasHtmlBlocks = TranslationsService.containsHtmlBlocks(text);
     const hasVariables = TranslationsService.containsVariables(text);
+    const notes: string[] = [];
 
+    // Add content type notes
     if (hasHtmlBlocks && hasVariables) {
-      return 'Contains HTML/code and variables - please be mindful of the structure when performing the translation';
+      notes.push('Contains HTML/code and variables');
     } else if (hasHtmlBlocks) {
-      return 'Contains HTML/code - please be mindful of the structure when performing the translation';
+      notes.push('Contains HTML/code');
     } else if (hasVariables) {
-      return 'Contains variable text - please be mindful of the structure when performing the translation';
+      notes.push('Contains variable text');
     }
 
-    return '';
+    // TODO: Add usage note - Remove due to API limitations and not able to idenfity usage for all kes/texts in all surveys.
+    if (usedInMultiplePlaces) {
+      notes.push('Used in multiple surveys');
+    }
+
+    return notes.length > 0
+      ? `${notes.join(' and ')} - please be mindful of the structure when performing the translation.`
+      : '';
   }
 
   /**

--- a/src/core/services/translations/translations-service.ts
+++ b/src/core/services/translations/translations-service.ts
@@ -98,7 +98,13 @@ export class TranslationsService extends BaseService {
       .toISOString()
       .replace(/[-:]/g, '')
       .replace(/\.\d{3}/, '');
-    const surveyIdsPart = options.surveys.map(survey => survey.id).join('_');
+    const isMultiSurvey = options.surveys.length > 1;
+    const rawSurveyIdsPart = options.surveys.map(survey => survey.id).join('_');
+    // Truncate survey IDs part if it's too long to avoid file system 255 character limit issues (considering additional suffixes and extensions)
+    const truncatedSurveyIdsPart = rawSurveyIdsPart.length > 200
+      ? rawSurveyIdsPart.slice(0, 200)
+      : rawSurveyIdsPart;
+    const surveyIdsPart = isMultiSurvey ? `${truncatedSurveyIdsPart}-multi` : truncatedSurveyIdsPart;
     const simplifiedTranslationsFileName = `${surveyIdsPart}-${timestamp}${FILE_EXTENSIONS.EXCEL}`;
     const simplifiedTranslationsFilePath = PathUtils.join(
       options.outputPath,
@@ -264,7 +270,7 @@ export class TranslationsService extends BaseService {
       // Build final combined map with joined locations
       keyLocationMap.forEach((value, key) => {
         combinedWhereUsedMap.set(key, {
-          location: value.locations.join('\n'),
+          location: value.locations.join(',\n'),
           type: value.type || 'unknown'
         });
       });
@@ -374,8 +380,7 @@ export class TranslationsService extends BaseService {
 
         const whereUsedInfo = combinedWhereUsedMap.get(keyValue);
         const whereUsedValue = whereUsedInfo?.location || '';
-        const usedInMultiplePlaces = whereUsedValue.includes('\n');
-        const notesToTranslator = this.generateNotesToTranslator(originalTextValue, usedInMultiplePlaces);
+        const notesToTranslator = this.generateNotesToTranslator(originalTextValue);
 
         const outputRow = outputHeaders.map(idx => {
           if (idx === -1) {
@@ -405,32 +410,23 @@ export class TranslationsService extends BaseService {
   /**
    * Generate notes to translator based on text content
    */
-  private generateNotesToTranslator(text: string, usedInMultiplePlaces: boolean): string {
+  private generateNotesToTranslator(text: string): string {
     if (!text) {
       return '';
     }
 
     const hasHtmlBlocks = TranslationsService.containsHtmlBlocks(text);
     const hasVariables = TranslationsService.containsVariables(text);
-    const notes: string[] = [];
 
-    // Add content type notes
     if (hasHtmlBlocks && hasVariables) {
-      notes.push('Contains HTML/code and variables');
+      return 'Contains HTML/code and variables - please be mindful of the structure when performing the translation';
     } else if (hasHtmlBlocks) {
-      notes.push('Contains HTML/code');
+      return 'Contains HTML/code - please be mindful of the structure when performing the translation';
     } else if (hasVariables) {
-      notes.push('Contains variable text');
+      return 'Contains variable text - please be mindful of the structure when performing the translation';
     }
 
-    // TODO: Add usage note - Remove due to API limitations and not able to idenfity usage for all kes/texts in all surveys.
-    if (usedInMultiplePlaces) {
-      notes.push('Used in multiple surveys');
-    }
-
-    return notes.length > 0
-      ? `${notes.join(' and ')} - please be mindful of the structure when performing the translation.`
-      : '';
+    return '';
   }
 
   /**

--- a/src/core/services/translations/types.ts
+++ b/src/core/services/translations/types.ts
@@ -39,7 +39,6 @@ export interface TranslationContext {
 export interface TranslationDownloadResult {
   processedFilePath: string;
   rawTranslationsFilePath?: string;
-  surveySpecFilePath?: string;
   missingLanguages: string[];
 }
 

--- a/src/core/services/translations/types.ts
+++ b/src/core/services/translations/types.ts
@@ -1,7 +1,7 @@
 import { SurveyItem } from '../surveys';
 
 export interface DownloadTranslationsOptions {
-  survey: SurveyItem;
+  surveys: SurveyItem[];
   outputPath: string;
   saveDebugFiles: boolean;
   languages: string;

--- a/src/core/services/translations/types.ts
+++ b/src/core/services/translations/types.ts
@@ -119,6 +119,11 @@ export interface TranslationImportChangesResponse {
   _allowed: string[];
 }
 
+export interface TranslationImportChangesItemLinks {
+  translation_locale?: { href: string; rel: string | null } | null;
+  translation_item?: { href: string; rel: string | null } | null;
+}
+
 export interface TranslationImportChangesItem {
   id: string;
   new_text: string;
@@ -128,6 +133,8 @@ export interface TranslationImportChangesItem {
   type: string;
   error_code?: string;
   error_message?: string;
+  locale_id?: string; // Custom addition to API response for easier access during processing
+  _links?: TranslationImportChangesItemLinks;
 }
 
 export interface TranslationIssueItem {

--- a/src/ui/formatting/output.ts
+++ b/src/ui/formatting/output.ts
@@ -1,4 +1,5 @@
 import { EMOJIS } from '../../core/config/constants';
+
 import { Colors } from './colors';
 
 export class OutputFormatter {

--- a/src/ui/formatting/progress.ts
+++ b/src/ui/formatting/progress.ts
@@ -1,5 +1,6 @@
 import { EMOJIS, UI_SETTINGS } from '../../core/config/constants';
 import { isVerboseEnabled } from '../../utils';
+
 import { Colors } from './colors';
 
 export class ProgressFormatter {

--- a/src/ui/formatting/tables.ts
+++ b/src/ui/formatting/tables.ts
@@ -182,11 +182,11 @@ export class TableFormatter {
       head: [
         Colors.tableHeader('ID'),
         Colors.tableHeader('Type'),
-        Colors.tableHeader('Category'),
+        Colors.tableHeader('Locale ID'),
         Colors.tableHeader('Old Text'),
         Colors.tableHeader('New Text'),
       ],
-      colWidths: [5, 14, 22, 38, 38],
+      colWidths: [5, 14, 38, 38, 38],
       style: {
         head: [],
         border: ['gray'],
@@ -197,7 +197,7 @@ export class TableFormatter {
       table.push([
         Colors.tableIndex((index + 1).toString()),
         Colors.tableContent(change.type || ''),
-        Colors.tableContent(change.translation_category || ''),
+        Colors.tableContent(change.locale_id || ''),
         Colors.muted(change.old_text || ''),
         Colors.success(change.new_text || ''),
       ]);

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -217,12 +217,14 @@ export function createYargsParser() {
             })
             // Download-specific options
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID, {
-              type: 'array',
+              type: 'string',
+              array: true,
               description: 'UUID(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME, {
-              type: 'array',
+              type: 'string',
+              array: true,
               description: 'Name(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
@@ -297,7 +299,7 @@ export function createYargsParser() {
               'Download translations by UUID'
             )
             .example(
-              `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.DOWNLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} f0473723-45f0-4397-b39e-d2bf3d955a20 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} g0473723-45f0-4397-b39e-d2bf3d955a21 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} h0473723-45f0-4397-b39e-d2bf3d955a22`,
+              `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.DOWNLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} f0473723-45f0-4397-b39e-d2bf3d955a20 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} 1fa05e9d-2f31-4ee0-8a72-17a2840d1e32 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} b3384f6a-22a1-4ff3-b1ca-a15d344e7557`,
               'Download translations for multiple surveys by UUID'
             )
             .example(

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -178,11 +178,21 @@ export function createYargsParser() {
             description: 'Filter survey programs by UUID',
           })
           .check(argv => {
-            if (argv[CLI_OPTIONS.SURVEYS.NAME] !== undefined && !String(argv[CLI_OPTIONS.SURVEYS.NAME]).trim()) {
-              throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.NAME)} value must not be empty`);
+            if (
+              argv[CLI_OPTIONS.SURVEYS.NAME] !== undefined &&
+              !String(argv[CLI_OPTIONS.SURVEYS.NAME]).trim()
+            ) {
+              throw new ValidationError(
+                `${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.NAME)} value must not be empty`
+              );
             }
-            if (argv[CLI_OPTIONS.SURVEYS.UUID] !== undefined && !String(argv[CLI_OPTIONS.SURVEYS.UUID]).trim()) {
-              throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.UUID)} value must not be empty`);
+            if (
+              argv[CLI_OPTIONS.SURVEYS.UUID] !== undefined &&
+              !String(argv[CLI_OPTIONS.SURVEYS.UUID]).trim()
+            ) {
+              throw new ValidationError(
+                `${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.UUID)} value must not be empty`
+              );
             }
             return true;
           })
@@ -219,13 +229,15 @@ export function createYargsParser() {
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID, {
               type: 'string',
               array: true,
-              description: 'UUID(s) of the survey program(s) (download only). Supports multiple values.',
+              description:
+                'UUID(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME, {
               type: 'string',
               array: true,
-              description: 'Name(s) of the survey program(s) (download only). Supports multiple values.',
+              description:
+                'Name(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.LANGUAGES, {
@@ -276,12 +288,16 @@ export function createYargsParser() {
                 // Guard against blank values like --survey-uuid ""
                 const uuids = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
                 if (uuids?.some(v => !String(v).trim())) {
-                  throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} values must not be empty`);
+                  throw new ValidationError(
+                    `${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} values must not be empty`
+                  );
                 }
 
                 const names = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
                 if (names?.some(v => !String(v).trim())) {
-                  throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} values must not be empty`);
+                  throw new ValidationError(
+                    `${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} values must not be empty`
+                  );
                 }
               }
 

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -208,13 +208,13 @@ export function createYargsParser() {
             })
             // Download-specific options
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID, {
-              type: 'string',
-              description: 'UUID of the survey program (download only)',
+              type: 'array',
+              description: 'UUID(s) of the survey program(s) (download only). Can specify multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME, {
-              type: 'string',
-              description: 'Name of the survey program (download only)',
+              type: 'array',
+              description: 'Name(s) of the survey program(s) (download only). Can specify multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.LANGUAGES, {
@@ -278,8 +278,16 @@ export function createYargsParser() {
               'Download translations by UUID'
             )
             .example(
+              `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.DOWNLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} f0473723-45f0-4397-b39e-d2bf3d955a20 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} g0473723-45f0-4397-b39e-d2bf3d955a21 ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} h0473723-45f0-4397-b39e-d2bf3d955a22`,
+              'Download translations for multiple surveys by UUID'
+            )
+            .example(
               `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.DOWNLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} "Customer Feedback"`,
               'Download translations by name'
+            )
+            .example(
+              `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.DOWNLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} "Customer Feedback" ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} "Product Survey"`,
+              'Download translations for multiple surveys by name'
             )
             .example(
               `$0 ${COMMANDS.TRANSLATIONS} ${SUB_COMMANDS.TRANSLATIONS.UPLOAD} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.FILE)}  ./my-translations.xlsx`,

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -272,16 +272,17 @@ export function createYargsParser() {
                     `For download: either ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} or ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} must be provided`
                   );
                 }
-              }
 
-              // Guard against blank values like --survey-uuid ""
-              const uuids = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
-              if (uuids?.some(v => !String(v).trim())) {
-                throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} values must not be empty`);
-              }
-              const names = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
-              if (names?.some(v => !String(v).trim())) {
-                throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} values must not be empty`);
+                // Guard against blank values like --survey-uuid ""
+                const uuids = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
+                if (uuids?.some(v => !String(v).trim())) {
+                  throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} values must not be empty`);
+                }
+
+                const names = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
+                if (names?.some(v => !String(v).trim())) {
+                  throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} values must not be empty`);
+                }
               }
 
               if (action === SUB_COMMANDS.TRANSLATIONS.UPLOAD) {

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -177,6 +177,15 @@ export function createYargsParser() {
             type: 'string',
             description: 'Filter survey programs by UUID',
           })
+          .check(argv => {
+            if (argv[CLI_OPTIONS.SURVEYS.NAME] !== undefined && !String(argv[CLI_OPTIONS.SURVEYS.NAME]).trim()) {
+              throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.NAME)} value must not be empty`);
+            }
+            if (argv[CLI_OPTIONS.SURVEYS.UUID] !== undefined && !String(argv[CLI_OPTIONS.SURVEYS.UUID]).trim()) {
+              throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.UUID)} value must not be empty`);
+            }
+            return true;
+          })
           .example(`$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST}`, 'List all surveys')
           .example(
             `$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILE)} caspian-prod`,
@@ -209,12 +218,12 @@ export function createYargsParser() {
             // Download-specific options
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID, {
               type: 'array',
-              description: 'UUID(s) of the survey program(s) (download only). Can specify multiple values.',
+              description: 'UUID(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME, {
               type: 'array',
-              description: 'Name(s) of the survey program(s) (download only). Can specify multiple values.',
+              description: 'Name(s) of the survey program(s) (download only). Supports multiple values.',
               requiresArg: true,
             })
             .option(CLI_OPTIONS.TRANSLATIONS.LANGUAGES, {
@@ -261,6 +270,16 @@ export function createYargsParser() {
                     `For download: either ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} or ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} must be provided`
                   );
                 }
+              }
+
+              // Guard against blank values like --survey-uuid ""
+              const uuids = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID];
+              if (uuids?.some(v => !String(v).trim())) {
+                throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_UUID)} values must not be empty`);
+              }
+              const names = argv[CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME];
+              if (names?.some(v => !String(v).trim())) {
+                throw new ValidationError(`${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.TRANSLATIONS.SURVEY_NAME)} values must not be empty`);
               }
 
               if (action === SUB_COMMANDS.TRANSLATIONS.UPLOAD) {

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -73,6 +73,12 @@ export class UI {
     surveys: SurveyItem[],
     getAdminSurveyEditorUrlById: (_id: string) => string
   ): void {
+    // To avoid displaying an empty table when no surveys are found, show a warning instead
+    if (surveys.length === 0) {
+      console.log(this.output.formatWarning('No survey programs found'));
+      return;
+    }
+
     console.log(Colors.info(`\n${EMOJIS.SURVEY} Survey Program(s):`));
     this.table.displaySurveysTable(surveys, getAdminSurveyEditorUrlById);
   }

--- a/src/ui/ui.ts
+++ b/src/ui/ui.ts
@@ -73,11 +73,6 @@ export class UI {
     surveys: SurveyItem[],
     getAdminSurveyEditorUrlById: (_id: string) => string
   ): void {
-    if (surveys.length === 0) {
-      console.log(this.output.formatWarning('No survey programs found'));
-      return;
-    }
-
     console.log(Colors.info(`\n${EMOJIS.SURVEY} Survey Program(s):`));
     this.table.displaySurveysTable(surveys, getAdminSurveyEditorUrlById);
   }

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -117,7 +117,7 @@ run_test "Translations Download multiple UUIDs accepted by parser" \
   "false"
 # Parser accepts multiple --survey-name flags; command fails at API call, which is expected
 run_test "Translations Download multiple names accepted by parser" \
-  "npm run dev -- translations download --survey-name 'Survey A' --survey-name 'Survey B' 2>/dev/null" \
+  "npm run dev -- translations download --survey-name 'Survey Dummy A' --survey-name 'Survey Dummy B' 2>/dev/null" \
   "false"
 # Parser accepts --survey-uuid and --survey-name together; command fails at API call, which is expected
 run_test "Translations Download UUID and name together accepted by parser" \

--- a/tests/test-cli.sh
+++ b/tests/test-cli.sh
@@ -104,6 +104,30 @@ run_test_with_output "Translations Help" "npm run dev -- translations --help" "T
 run_test_with_output "Translations Download Error" "npm run dev -- translations download" "For download: either --survey-uuid or --survey-name must be provided"
 run_test_with_output "Translations Upload Error" "npm run dev -- translations upload" "For upload: --file must be provided"
 
+# Multi-survey / parser validation tests
+run_test_with_output "Translations Download blank UUID rejected" \
+  "npm run dev -- translations download --survey-uuid ''" \
+  "survey-uuid values must not be empty"
+run_test_with_output "Translations Download blank name rejected" \
+  "npm run dev -- translations download --survey-name ''" \
+  "survey-name values must not be empty"
+# Parser accepts multiple --survey-uuid flags; command fails at API call (no real survey), which is expected
+run_test "Translations Download multiple UUIDs accepted by parser" \
+  "npm run dev -- translations download --survey-uuid uuid-one --survey-uuid uuid-two 2>/dev/null" \
+  "false"
+# Parser accepts multiple --survey-name flags; command fails at API call, which is expected
+run_test "Translations Download multiple names accepted by parser" \
+  "npm run dev -- translations download --survey-name 'Survey A' --survey-name 'Survey B' 2>/dev/null" \
+  "false"
+# Parser accepts --survey-uuid and --survey-name together; command fails at API call, which is expected
+run_test "Translations Download UUID and name together accepted by parser" \
+  "npm run dev -- translations download --survey-uuid some-uuid --survey-name 'Some Survey' 2>/dev/null" \
+  "false"
+# Duplicate UUIDs are accepted by the parser; deduplication happens inside the command
+run_test "Translations Download duplicate UUID accepted by parser" \
+  "npm run dev -- translations download --survey-uuid same-uuid --survey-uuid same-uuid 2>/dev/null" \
+  "false"
+
 # Error Handling Tests
 run_test_with_output "Invalid Command" "npm run dev -- invalid-command" "Unknown argument: invalid-command"
 run_test_with_output "No Command" "npm run dev --" "You must provide a command"

--- a/tests/test-parser.ts
+++ b/tests/test-parser.ts
@@ -7,6 +7,7 @@
 
 import { CLIApplication } from '../src/app/cli';
 import { CoreContainer } from '../src/core';
+import { createYargsParser } from '../src/ui/parser/parser';
 
 interface TestResult {
   name: string;
@@ -76,6 +77,68 @@ class ParseTester {
       process.argv = ['node', 'mec', 'translations', 'download', '--profile', 'default'];
       
       // Translations command parsing structure is valid
+    });
+
+    await this.runTest('Translations download: multiple --survey-uuid values parsed as array', async () => {
+      process.argv = [
+        'node', 'mec', 'translations', 'download',
+        '--survey-uuid', 'uuid-one',
+        '--survey-uuid', 'uuid-two',
+      ];
+      const argv = createYargsParser().parseSync();
+      const uuids = argv['survey-uuid'] as string[];
+      if (!Array.isArray(uuids)) {
+        throw new Error(`Expected survey-uuid to be an array, got ${typeof uuids}`);
+      }
+      if (uuids.length !== 2 || uuids[0] !== 'uuid-one' || uuids[1] !== 'uuid-two') {
+        throw new Error(`Expected ['uuid-one', 'uuid-two'], got ${JSON.stringify(uuids)}`);
+      }
+    });
+
+    await this.runTest('Translations download: multiple --survey-name values parsed as array', async () => {
+      process.argv = [
+        'node', 'mec', 'translations', 'download',
+        '--survey-name', 'Survey A',
+        '--survey-name', 'Survey B',
+      ];
+      const argv = createYargsParser().parseSync();
+      const names = argv['survey-name'] as string[];
+      if (!Array.isArray(names)) {
+        throw new Error(`Expected survey-name to be an array, got ${typeof names}`);
+      }
+      if (names.length !== 2 || names[0] !== 'Survey A' || names[1] !== 'Survey B') {
+        throw new Error(`Expected ['Survey A', 'Survey B'], got ${JSON.stringify(names)}`);
+      }
+    });
+
+    await this.runTest('Translations download: --survey-uuid and --survey-name accepted together by parser', async () => {
+      process.argv = [
+        'node', 'mec', 'translations', 'download',
+        '--survey-uuid', 'some-uuid',
+        '--survey-name', 'Some Survey',
+      ];
+      const argv = createYargsParser().parseSync();
+      const uuids = argv['survey-uuid'] as string[];
+      const names = argv['survey-name'] as string[];
+      if (!Array.isArray(uuids) || uuids[0] !== 'some-uuid') {
+        throw new Error(`Expected survey-uuid=['some-uuid'], got ${JSON.stringify(uuids)}`);
+      }
+      if (!Array.isArray(names) || names[0] !== 'Some Survey') {
+        throw new Error(`Expected survey-name=['Some Survey'], got ${JSON.stringify(names)}`);
+      }
+    });
+
+    await this.runTest('Translations download: duplicate --survey-uuid kept by parser (dedup happens in command)', async () => {
+      process.argv = [
+        'node', 'mec', 'translations', 'download',
+        '--survey-uuid', 'same-uuid',
+        '--survey-uuid', 'same-uuid',
+      ];
+      const argv = createYargsParser().parseSync();
+      const uuids = argv['survey-uuid'] as string[];
+      if (!Array.isArray(uuids) || uuids.length !== 2) {
+        throw new Error(`Parser should preserve duplicates (dedup is in command layer); got ${JSON.stringify(uuids)}`);
+      }
     });
   }
 


### PR DESCRIPTION
## What's New

### Download translations for multiple surveys at once
The `translations download` command now accepts multiple surveys. Translations from all selected surveys are merged into a single Excel file.

```sh
mec translations download --survey-uuid f0473723-45f0-4397-b39e-d2bf3d955a20
mec translations download --survey-name "Customer Feedback"
```
### With this enhancement, you can specify multiple surveys:
```sh
mec translations download --survey-uuid "f0473723-45f0-4397-b39e-d2bf3d955a20" --survey-uuid "f0473723-45f0-4397-b39e-d2bf3d955a21"
mec translations download --survey-name "Customer Feedback" --survey-name "Employee Feedback"
```

### Improved "Where Used" column
- Shows all matching locations across the selected surveys.
- Column header updated to clarify it applies to the selected surveys only.
- Fixed: Grid elements showed empty "Where Used" paths.
- Fixed: Elements on pages with "Unknown" in their name were incorrectly excluded from the output.

### Improved Translations dry-run preview now grouped by language
- Changes are deduplicated and grouped by locale - a single edited row no longer appears twice due to survey/mobile context variants.

## Bug Fixes
- Fixed a crash when looking up a survey by a UUID such as `"."` or `"#"` that causes the API to return an empty response instead of a 404.
- Uploading a file with a name that is too long now shows a clear error message instead of a cryptic system error.