### PR TITLE
docs: improve README configuration section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,43 @@
 
 This application is a reference implementation for interacting with Medallia Experience Cloud (MEC) services via the command line.
 
+---
+
+## Table of Contents
+
+- [Quick Start](#-quick-start)
+- [Installation](#-installation)
+- [Configuration](#-configuration)
+- [Usage](#-usage)
+  - [Profile Management](#-profile-management)
+  - [Survey Operations](#-survey-operations)
+  - [Translation Operations](#-translation-operations)
+- [Options Reference](#-options-reference)
+- [Help](#-help)
+- [Project Structure](#-project-structure)
+- [License](#-license)
+
+---
+
 ## Quick Start
 
-### Installation
+```bash
+# 1. Install
+brew tap medallia/mec-cli && brew install mec
 
-#### Standard User Installation
+# 2. Configure (interactive prompts will guide you)
+mec configure
+
+# 3. Start using it!
+mec surveys list
+mec translations download --survey-name "feedback"
+```
+
+---
+
+## Installation
+
+### Standard User Installation (Recommended)
 
 **Prerequisites:**
 - [Homebrew](https://brew.sh/) (macOS/Linux package manager)
@@ -29,7 +61,7 @@ To upgrade to the latest version:
 brew upgrade mec
 ```
 
-#### Developer Installation
+### Developer Installation
 
 **Prerequisites:**
 - [Node.js](https://nodejs.org/) (version 20 or higher)
@@ -51,48 +83,48 @@ npm run build
 ./bin/mec --help
 ```
 
-> **Developer Tip:** For local development, add `./bin` to your `PATH` or create an alias for easier use:
->
-> ```bash
-> # For bash users
-> echo "alias mec='$(pwd)/bin/mec'" >> ~/.bashrc && source ~/.bashrc
-> 
-> # For zsh users  
-> echo "alias mec='$(pwd)/bin/mec'" >> ~/.zshrc && source ~/.zshrc
-> ```
->
-> After this, you can run `mec` from anywhere in your terminal.
->
-> **Note:** If you later install via Homebrew, remove the alias or PATH modification as `brew install mec` automatically adds `mec` to your PATH.
+<details>
+<summary>💡 Developer Tip: Make <code>mec</code> accessible globally</summary>
 
-### Configuration
+For local development, add `./bin` to your `PATH` or create an alias for easier use:
 
-Configure authentication and connection settings using profiles. Profiles store your credentials and preferences for connecting to MEC environments.
+```bash
+# For bash users
+echo "alias mec='$(pwd)/bin/mec'" >> ~/.bashrc && source ~/.bashrc
 
-#### Prerequisites
+# For zsh users  
+echo "alias mec='$(pwd)/bin/mec'" >> ~/.zshrc && source ~/.zshrc
+```
 
-Before configuring a profile, you need to obtain the following credentials from your MEC instance:
+After this, you can run `mec` from anywhere in your terminal.
 
-**Required Credentials:**
+**Note:** If you later install via Homebrew, remove the alias or PATH modification as `brew install mec` automatically adds `mec` to your PATH.
 
-1. **OAuth Client ID & Secret**
-   - Create an AppID account in MEC
-   - Generate an OAuth Client using the **Client Credentials Grant** type
-   - Note: This client will be used for API authentication
+</details>
 
-2. **OAuth Token URL**
-   - Retrieved from the OAuth configuration in your MEC instance
-   - Format: `https://{host}/oauth/{realm}/token`
-   - Example: `https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token`
+---
 
-3. **API Gateway URL (Public API Hostname)**
-   - Found under **"Public APIs Setup"** in your MEC instance
-   - Format: `https://{host}.apis.medallia.com`
-   - Example: `https://admin-suite-stable-merlin.apis.medallia.com`
+## Configuration
 
-> **Need Help?** Detailed instructions for setting up these credentials are available in the [Medallia documentation](https://docs.medallia.com). If you encounter any issues, please contact your Medallia administrator or support team.
+Configure authentication and connection settings using **profiles**. Profiles store your credentials and preferences for connecting to MEC environments.
 
-#### Method 1: Interactive Configuration (Recommended)
+### Before You Begin
+
+You need to obtain the following credentials from your MEC instance:
+
+| # | Credential | Where to find it | Example |
+|---|-----------|-------------------|---------|
+| 1 | **OAuth Client ID & Secret** | Create an AppID account in MEC → Generate an OAuth Client using the **Client Credentials Grant** type | *(used for API authentication)* |
+| 2 | **OAuth Token URL** | OAuth configuration in your MEC instance | `https://caspian.medallia.com/oauth/caspian/token` |
+| 3 | **API Gateway URL** | Under **"Public APIs Setup"** in your MEC instance | `https://caspian-caspian.apis.medallia.com` |
+
+**URL Formats:**
+- Token URL: `https://{reporting-instance}/oauth/{tenant}/token`
+- API Gateway: `https://{reporting-instance}-{tenant}.apis.medallia.com`
+
+> 💬 **Need Help?** Detailed instructions for setting up these credentials are available in the [Medallia documentation](https://docs.medallia.com). If you encounter any issues, please contact your Medallia administrator or support team.
+
+### Method 1: Interactive Configuration (Recommended)
 
 The interactive mode guides you through setup with prompts:
 
@@ -101,7 +133,7 @@ The interactive mode guides you through setup with prompts:
 mec configure
 
 # Configure named profile
-mec configure --profile "merlin-qa"
+mec configure --profile "caspian-qa"
 ```
 
 Use `--quick` flag to skip optional settings and use defaults:
@@ -109,45 +141,52 @@ Use `--quick` flag to skip optional settings and use defaults:
 mec configure --quick
 ```
 
-#### Method 2: Command-Line Arguments
+### Method 2: Command-Line Arguments
 
 Pass all settings directly via command-line flags for non-interactive setup:
 
 ```bash
 # Configure default profile
 mec configure \
-  --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
+  --token-url "https://caspian.medallia.com/oauth/caspian/token" \
   --client-id "mec_cli_integration" \
   --client-secret "your-client-secret" \
-  --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com"
+  --api-gateway-url "https://caspian-caspian.apis.medallia.com"
 
 # Configure named profile with optional settings
 mec configure \
-  --profile "merlin-qa" \
-  --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
+  --profile "caspian-qa" \
+  --token-url "https://caspian.medallia.com/oauth/caspian/token" \
   --client-id "mec_cli_integration" \
   --client-secret "your-client-secret" \
-  --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com" \
+  --api-gateway-url "https://caspian-caspian.apis.medallia.com" \
   --languages "Spanish,French" \
   --output-path "~/Downloads/" \
   --include-html-blocks
 ```
 
 **Required Parameters:**
-- `--token-url`: MEC OAuth token endpoint
-- `--client-id`: MEC OAuth client ID
-- `--client-secret`: MEC OAuth client secret
-- `--api-gateway-url`: MEC API gateway base URL (Public API Hostname) 
+
+| Parameter | Description |
+|-----------|-------------|
+| `--token-url` | MEC OAuth token endpoint |
+| `--client-id` | MEC OAuth client ID |
+| `--client-secret` | MEC OAuth client secret |
+| `--api-gateway-url` | MEC API gateway base URL (Public API Hostname) |
 
 **Optional Parameters:**
-- `--profile`: Profile name (default: `default`)
-- `--languages`: Comma-separated language list (default: `English`)
-- `--output-path`: Download directory (default: `./`)
-- `--include-html-blocks`: Include HTML content in translations (default: `false`)
 
-#### Method 3: Direct File Editing
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `--profile` | Profile name | `default` |
+| `--languages` | Comma-separated list of translation languages | `English` |
+| `--output-path` | Download directory | `./` |
+| `--include-html-blocks` | Include HTML content in translations | `false` |
 
-Advanced users can manually edit the configuration file:
+### Method 3: Direct File Editing
+
+<details>
+<summary>Advanced: Edit the config file manually</summary>
 
 **Location:** `${USER_HOME}/.mec/profiles`
 
@@ -155,37 +194,43 @@ Advanced users can manually edit the configuration file:
 
 ```ini
 [default]
-tokenUrl = https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token
-oAuthClientId = digital_integration
+tokenUrl = https://caspian.medallia.com/oauth/caspian/token
+oAuthClientId = mec_cli_integration
 oAuthClientSecret = your-client-secret
-apiGatewayUrl = https://admin-suite-stable-merlin.apis.medallia.com
+apiGatewayUrl = https://caspian-caspian.apis.medallia.com
 languages = English
 outputPath = ./
 includeHtmlBlocks = false
 
-[merlin-qa]
-tokenUrl = https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token
-oAuthClientId = digital_integration
+[caspian-qa]
+tokenUrl = https://caspian.medallia.com/oauth/caspian/token
+oAuthClientId = mec_cli_integration
 oAuthClientSecret = your-client-secret
-apiGatewayUrl = https://admin-suite-stable-merlin.apis.medallia.com
+apiGatewayUrl = https://caspian-caspian.apis.medallia.com
 languages = Spanish,French
 outputPath = ~/Downloads/
 includeHtmlBlocks = true
 ```
 
-> **Security Note:** The configuration file is automatically created with secure file permissions (600 - owner read/write only) to protect sensitive credentials.
+> 🔒 **Security Note:** The configuration file is automatically created with secure file permissions (600 - owner read/write only) to protect sensitive credentials.
+
+</details>
+
+---
 
 ## Usage
 
 ### Profile Management
+
 ```bash
 mec profiles list                             # List all profiles
 mec profiles list --detailed                  # Show detailed profile info
-mec profiles show --profile "merlin-sbx"      # Show specific profile
-mec profiles delete --profile "merlin-prod"   # Delete a profile
+mec profiles show --profile "caspian-sbx"      # Show specific profile
+mec profiles delete --profile "caspian-prod"   # Delete a profile
 ```
 
 ### Survey Operations
+
 ```bash
 mec surveys list                                                    # List all surveys
 mec surveys list --name "feedback"                                  # Filter by name
@@ -195,6 +240,7 @@ mec surveys list --uuid "dfc33eb1-2039-4bb5-b682-0a9dc894b2e5"      # Find by UU
 ### Translation Operations
 
 #### Download
+
 ```bash
 # Download translations by survey name
 mec translations download --survey-name "feedback"
@@ -214,26 +260,54 @@ mec translations download \
 ```
 
 #### Upload
+
 ```bash
 # Upload translations
 mec translations upload --file "translations.xlsx"
 
-# Dry run (preview changes)
+# Dry run (preview changes without uploading)
 mec translations upload --file "translations.xlsx" --pretend-upload
 ```
 
-### Options
+---
+
+## Options Reference
+
+These options can be used with most commands:
 
 | Option | Description |
 |--------|-------------|
-| `--profile` | Profile to use |
-| `--languages` | Comma-separated language list |
-| `--output-path` | Custom output directory |
-| `--include-html-blocks` | Include HTML content |
+| `--profile` | Profile to use for this command |
+| `--languages` | Comma-separated list of translation languages (e.g., `"Spanish,French"`) |
+| `--output-path` | Custom output directory for downloads |
+| `--include-html-blocks` | Include HTML content in translation files |
 | `--save-debug-files` | Save debug files for troubleshooting |
-| `--pretend-upload` | Dry run mode |
+| `--pretend-upload` | Dry run mode — preview changes without uploading |
+
+---
+
+## Help
+
+Get help at any level — just append `--help`:
+
+```bash
+mec --help                           # Main help
+mec configure --help                 # Command-specific help
+mec translations download --help     # Subcommand help
+```
+
+**Quick troubleshooting checklist:**
+- Have you run `mec configure` to set up a profile?
+- Are your OAuth credentials correct? Check with your MEC administrator.
+- Try `--save-debug-files` to capture diagnostic information.
+- Verify your active profile: `mec profiles show`
+
+---
 
 ## Project Structure
+
+<details>
+<summary>Click to view project structure</summary>
 
 ```
 src/
@@ -247,13 +321,9 @@ src/
 └── utils/                 # Utilities (logging, helpers, errors)
 ```
 
-## Help
+</details>
 
-```bash
-mec --help                           # Main help
-mec configure --help                 # Command-specific help
-mec translations download --help     # Subcommand help
-```
+---
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Pass all settings directly via command-line flags for non-interactive setup:
 # Configure default profile
 mec configure \
   --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
-  --client-id "digital_integration" \
+  --client-id "mec_cli_integration" \
   --client-secret "your-client-secret" \
   --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com"
 
@@ -125,7 +125,7 @@ mec configure \
 mec configure \
   --profile "merlin-qa" \
   --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
-  --client-id "digital_integration" \
+  --client-id "mec_cli_integration" \
   --client-secret "your-client-secret" \
   --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com" \
   --languages "Spanish,French" \
@@ -135,9 +135,9 @@ mec configure \
 
 **Required Parameters:**
 - `--token-url`: MEC OAuth token endpoint
-- `--client-id`: OAuth client ID
-- `--client-secret`: OAuth client secret
-- `--api-gateway-url`: MEC API gateway base URL, it is called Public API Hostname 
+- `--client-id`: MEC OAuth client ID
+- `--client-secret`: MEC OAuth client secret
+- `--api-gateway-url`: MEC API gateway base URL (Public API Hostname) 
 
 **Optional Parameters:**
 - `--profile`: Profile name (default: `default`)

--- a/README.md
+++ b/README.md
@@ -67,26 +67,113 @@ npm run build
 
 ### Configuration
 
-Configuration profiles are stored in `${USER_HOME}/.mec/profiles` as a human-readable INI file with secure file permissions (owner read/write only). Profiles can be managed via commands or edited directly in the file.
+Configure authentication and connection settings using profiles. Profiles store your credentials and preferences for connecting to MEC environments.
+
+#### Prerequisites
+
+Before configuring a profile, you need to obtain the following credentials from your MEC instance:
+
+**Required Credentials:**
+
+1. **OAuth Client ID & Secret**
+   - Create an AppID account in MEC
+   - Generate an OAuth Client using the **Client Credentials Grant** type
+   - Note: This client will be used for API authentication
+
+2. **OAuth Token URL**
+   - Retrieved from the OAuth configuration in your MEC instance
+   - Format: `https://{host}/oauth/{realm}/token`
+   - Example: `https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token`
+
+3. **API Gateway URL (Public API Hostname)**
+   - Found under **"Public APIs Setup"** in your MEC instance
+   - Format: `https://{host}.apis.medallia.com`
+   - Example: `https://admin-suite-stable-merlin.apis.medallia.com`
+
+> **Need Help?** Detailed instructions for setting up these credentials are available in the [Medallia documentation](https://docs.medallia.com). If you encounter any issues, please contact your Medallia administrator or support team.
+
+#### Method 1: Interactive Configuration (Recommended)
+
+The interactive mode guides you through setup with prompts:
 
 ```bash
-# Configure your default profile
+# Configure default profile
+mec configure
+
+# Configure named profile
+mec configure --profile "merlin-qa"
+```
+
+Use `--quick` flag to skip optional settings and use defaults:
+```bash
+mec configure --quick
+```
+
+#### Method 2: Command-Line Arguments
+
+Pass all settings directly via command-line flags for non-interactive setup:
+
+```bash
+# Configure default profile
 mec configure \
   --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
   --client-id "digital_integration" \
   --client-secret "your-client-secret" \
   --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com"
 
-# Create named profiles
+# Configure named profile with optional settings
 mec configure \
   --profile "merlin-qa" \
-  --token-url "..." \
-  --client-id "..." \
-  --client-secret "..." \
-  --api-gateway-url "..." \
+  --token-url "https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token" \
+  --client-id "digital_integration" \
+  --client-secret "your-client-secret" \
+  --api-gateway-url "https://admin-suite-stable-merlin.apis.medallia.com" \
   --languages "Spanish,French" \
-  --output-path "~/Downloads/"
+  --output-path "~/Downloads/" \
+  --include-html-blocks
 ```
+
+**Required Parameters:**
+- `--token-url`: MEC OAuth token endpoint
+- `--client-id`: OAuth client ID
+- `--client-secret`: OAuth client secret
+- `--api-gateway-url`: MEC API gateway base URL, it is called Public API Hostname 
+
+**Optional Parameters:**
+- `--profile`: Profile name (default: `default`)
+- `--languages`: Comma-separated language list (default: `English`)
+- `--output-path`: Download directory (default: `./`)
+- `--include-html-blocks`: Include HTML content in translations (default: `false`)
+
+#### Method 3: Direct File Editing
+
+Advanced users can manually edit the configuration file:
+
+**Location:** `${USER_HOME}/.mec/profiles`
+
+**Format:** INI file with secure permissions (owner read/write only)
+
+```ini
+[default]
+tokenUrl = https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token
+oAuthClientId = digital_integration
+oAuthClientSecret = your-client-secret
+apiGatewayUrl = https://admin-suite-stable-merlin.apis.medallia.com
+languages = English
+outputPath = ./
+includeHtmlBlocks = false
+
+[merlin-qa]
+tokenUrl = https://admin-suite-stable.qa.den.medallia.com/oauth/merlin/token
+oAuthClientId = digital_integration
+oAuthClientSecret = your-client-secret
+apiGatewayUrl = https://admin-suite-stable-merlin.apis.medallia.com
+languages = Spanish,French
+outputPath = ~/Downloads/
+includeHtmlBlocks = true
+```
+
+> **Security Note:** The configuration file is automatically created with secure file permissions (600 - owner read/write only) to protect sensitive credentials.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ After this, you can run `mec` from anywhere in your terminal.
 
 ## Configuration
 
-Configure authentication and connection settings using **profiles**. Profiles store your credentials and preferences for connecting to MEC environments.
+Configure authentication and connection settings using **profiles**. Each profile stores credentials and preferences for connecting to a specific MEC instance or environment. You can create multiple profiles to easily switch between different MEC instances and their respective environments (e.g., Instance A production, Instance A QA, Instance B production, Instance B sandbox).
 
 ### Before You Begin
 
@@ -156,10 +156,10 @@ mec configure \
 # Configure named profile with optional settings
 mec configure \
   --profile "caspian-qa" \
-  --token-url "https://caspian.medallia.com/oauth/caspian/token" \
+  --token-url "https://caspian.qa.medallia.com/oauth/caspian/token" \
   --client-id "mec_cli_integration" \
   --client-secret "your-client-secret" \
-  --api-gateway-url "https://caspian-caspian.apis.medallia.com" \
+  --api-gateway-url "https://caspian-caspian.apis.qa.medallia.com" \
   --languages "Spanish,French" \
   --output-path "~/Downloads/" \
   --include-html-blocks
@@ -179,7 +179,7 @@ mec configure \
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `--profile` | Profile name | `default` |
-| `--languages` | Comma-separated list of translation languages | `English` |
+| `--languages` | Comma-separated list of translation languages | `"English,Spanish,French"` |
 | `--output-path` | Download directory | `./` |
 | `--include-html-blocks` | Include HTML content in translations | `false` |
 
@@ -203,10 +203,10 @@ outputPath = ./
 includeHtmlBlocks = false
 
 [caspian-qa]
-tokenUrl = https://caspian.medallia.com/oauth/caspian/token
+tokenUrl = https://caspian.qa.medallia.com/oauth/caspian/token
 oAuthClientId = mec_cli_integration
 oAuthClientSecret = your-client-secret
-apiGatewayUrl = https://caspian-caspian.apis.medallia.com
+apiGatewayUrl = https://caspian-caspian.apis.qa.medallia.com
 languages = Spanish,French
 outputPath = ~/Downloads/
 includeHtmlBlocks = true
@@ -225,8 +225,8 @@ includeHtmlBlocks = true
 ```bash
 mec profiles list                             # List all profiles
 mec profiles list --detailed                  # Show detailed profile info
-mec profiles show --profile "caspian-sbx"      # Show specific profile
-mec profiles delete --profile "caspian-prod"   # Delete a profile
+mec profiles show --name "caspian-sbx"        # Show specific profile
+mec profiles delete --name "caspian-prod"     # Delete a profile
 ```
 
 ### Survey Operations
@@ -262,11 +262,11 @@ mec translations download \
 #### Upload
 
 ```bash
-# Upload translations
-mec translations upload --file "translations.xlsx"
-
 # Dry run (preview changes without uploading)
 mec translations upload --file "translations.xlsx" --pretend-upload
+
+# Upload translations
+mec translations upload --file "translations.xlsx"
 ```
 
 ---
@@ -281,7 +281,8 @@ These options can be used with most commands:
 | `--languages` | Comma-separated list of translation languages (e.g., `"Spanish,French"`) |
 | `--output-path` | Custom output directory for downloads |
 | `--include-html-blocks` | Include HTML content in translation files |
-| `--save-debug-files` | Save debug files for troubleshooting |
+| `--verbose`, `-v` | Enable verbose logging for detailed output |
+| `--save-debug-files`, `-d` | Save debug files for troubleshooting |
 | `--pretend-upload` | Dry run mode — preview changes without uploading |
 
 ---
@@ -298,9 +299,8 @@ mec translations download --help     # Subcommand help
 
 **Quick troubleshooting checklist:**
 - Have you run `mec configure` to set up a profile?
-- Are your OAuth credentials correct? Check with your MEC administrator.
-- Try `--save-debug-files` to capture diagnostic information.
-- Verify your active profile: `mec profiles show`
+- Are your OAuth credentials correct? Check with your MEC instance/administrator.
+- Try `--verbose` or `--save-debug-files` to capture diagnostic information.
 
 ---
 

--- a/src/ui/parser/parser.ts
+++ b/src/ui/parser/parser.ts
@@ -106,13 +106,13 @@ export function createYargsParser() {
               })
               .example(`$0 ${COMMANDS.CONFIGURE}`, 'Interactive setup')
               .example(`$0 ${COMMANDS.CONFIGURE} --quick`, 'Quick setup (required fields only)')
-              .example(`$0 ${COMMANDS.CONFIGURE} merlin-prod`, 'Configure specific profile')
+              .example(`$0 ${COMMANDS.CONFIGURE} caspian-prod`, 'Configure specific profile')
               .example(
-                `$0 ${COMMANDS.CONFIGURE} merlin-prod 
-                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.TOKEN_URL)} https://merlin.medallia.com/oauth/merlin/token 
-                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.OAUTH_CLIENT_ID)} medallia_merlin 
+                `$0 ${COMMANDS.CONFIGURE} caspian-prod 
+                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.TOKEN_URL)} https://caspian.medallia.com/oauth/caspian/token 
+                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.OAUTH_CLIENT_ID)} medallia_caspian 
                   ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.OAUTH_CLIENT_SECRET)} some-client-secret
-                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.API_GATEWAY_URL)} https://merlin-merlin.apis.medallia.com/`,
+                  ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILES.API_GATEWAY_URL)} https://caspian-caspian.apis.medallia.com/`,
                 'Non-interactive configuration for a specific profile'
               )
           );
@@ -179,8 +179,8 @@ export function createYargsParser() {
           })
           .example(`$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST}`, 'List all surveys')
           .example(
-            `$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILE)} merlin-prod`,
-            'List surveys using merlin-prod profile'
+            `$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.PROFILE)} caspian-prod`,
+            'List surveys using caspian-prod profile'
           )
           .example(
             `$0 ${COMMANDS.SURVEYS} ${SUB_COMMANDS.SURVEYS.LIST} ${CLI_OPTIONS.WITH_PREFIX(CLI_OPTIONS.SURVEYS.NAME)} feedback`,

--- a/src/ui/prompts/configuration.ts
+++ b/src/ui/prompts/configuration.ts
@@ -95,7 +95,7 @@ export class ConfigurationPrompt {
       {
         type: 'input',
         name: PROFILE_KEYS.LANGUAGES,
-        message: 'Default Languages:',
+        message: 'Default languages for translations (comma-separated):',
         default: getDefault('languages', PROFILE_DEFAULTS.LANGUAGES),
       },
       {


### PR DESCRIPTION
- Add OAuth credential prerequisites
- Clarify three configuration methods
- Document all parameters and defaults